### PR TITLE
Fix WTForms field overwriting on POST in course enrollment

### DIFF
--- a/now_lms/vistas/courses/enrollment.py
+++ b/now_lms/vistas/courses/enrollment.py
@@ -166,6 +166,60 @@ def _is_audit_enrollment(mode: str, course_obj: Curso) -> bool:
     return mode == "audit" and course_obj.auditable
 
 
+def _check_unverified_email_restriction(course_obj: Curso) -> bool:
+    """Check if the student has restricted access because of unverified email.
+
+    Flashes a message and returns True if restricted, False otherwise.
+    """
+    if course_obj.pagado and usuario_requiere_verificacion_email():
+        flash(
+            "Debe verificar su correo electrónico para inscribirse en cursos de pago o usar cupones. "
+            "Los cursos gratuitos están disponibles sin verificación.",
+            "warning",
+        )
+        return True
+    return False
+
+
+def _process_validated_enrollment(
+    form,
+    course_obj: Curso,
+    pricing,
+    mode: str,
+    course_code: str,
+) -> Response:
+    """Handle PagoForm submission when it has been successfully validated."""
+    pago = _build_pago_from_form(form, course_obj, pricing.final_price)
+
+    # Add coupon information to payment description
+    if pricing.applied_coupon:
+        pago.descripcion = f"Cupón aplicado: {pricing.applied_coupon.code} (Descuento: {pricing.discount_amount})"
+
+    # Handle different enrollment modes
+    if _is_free_enrollment(course_obj, pricing.final_price):
+        pago.estado = "completed"
+        success_message = _build_coupon_flash_message(
+            pricing.applied_coupon, pricing.final_price, pricing.discount_amount
+        )
+        return _finalize_completed_enrollment(
+            pago,
+            course_code,
+            pricing.applied_coupon,
+            pricing.final_price,
+            pricing.discount_amount,
+            success_message,
+        )
+
+    if _is_audit_enrollment(mode, course_obj):
+        pago.audit = True
+        pago.estado = "completed"  # Audit enrollment is completed immediately
+        pago.monto = 0
+        pago.metodo = "audit"
+        return _finalize_completed_enrollment(pago, course_code)
+
+    return _process_paid_enrollment(pago, course_code)
+
+
 @course.route("/course/<course_code>/enroll", methods=["GET", "POST"])
 @login_required
 @perfil_requerido("student")
@@ -183,14 +237,7 @@ def course_enroll(course_code: str) -> str | Response:
     coupon_code = request.args.get("coupon_code", "") or request.form.get("coupon_code", "")
     pricing = _calculate_enrollment_pricing(_curso, coupon_code, _usuario)
 
-    # Check if user has unverified email and is trying to enroll in paid course or use coupon
-    if _curso.pagado and usuario_requiere_verificacion_email():
-        # User has unverified email - only allow free enrollment without coupons
-        flash(
-            "Debe verificar su correo electrónico para inscribirse en cursos de pago o usar cupones. "
-            "Los cursos gratuitos están disponibles sin verificación.",
-            "warning",
-        )
+    if _check_unverified_email_restriction(_curso):
         return redirect(url_for(VISTA_CURSOS, course_code=course_code))
 
     if pricing.validation_error:
@@ -208,33 +255,7 @@ def course_enroll(course_code: str) -> str | Response:
             coupon_form.coupon_code.data = coupon_code
 
     if form.validate_on_submit():
-        pago = _build_pago_from_form(form, _curso, pricing.final_price)
-
-        # Add coupon information to payment description
-        if pricing.applied_coupon:
-            pago.descripcion = f"Cupón aplicado: {pricing.applied_coupon.code} (Descuento: {pricing.discount_amount})"
-
-        # Handle different enrollment modes
-        if _is_free_enrollment(_curso, pricing.final_price):
-            pago.estado = "completed"
-            success_message = _build_coupon_flash_message(pricing.applied_coupon, pricing.final_price, pricing.discount_amount)
-            return _finalize_completed_enrollment(
-                pago,
-                course_code,
-                pricing.applied_coupon,
-                pricing.final_price,
-                pricing.discount_amount,
-                success_message,
-            )
-
-        if _is_audit_enrollment(_modo, _curso):
-            pago.audit = True
-            pago.estado = "completed"  # Audit enrollment is completed immediately
-            pago.monto = 0
-            pago.metodo = "audit"
-            return _finalize_completed_enrollment(pago, course_code)
-
-        return _process_paid_enrollment(pago, course_code)
+        return _process_validated_enrollment(form, _curso, pricing, _modo, course_code)
 
     return render_template(
         "learning/curso/enroll.html",

--- a/now_lms/vistas/courses/enrollment.py
+++ b/now_lms/vistas/courses/enrollment.py
@@ -199,12 +199,13 @@ def course_enroll(course_code: str) -> str | Response:
     form = PagoForm()
     coupon_form = CouponApplicationForm()
 
-    # Pre-fill form data
-    form.nombre.data = _usuario.nombre
-    form.apellido.data = _usuario.apellido
-    form.correo_electronico.data = _usuario.correo_electronico
-    if coupon_code:
-        coupon_form.coupon_code.data = coupon_code
+    # Pre-fill form data only on GET requests to avoid overwriting user submission on POST
+    if request.method == "GET":
+        form.nombre.data = _usuario.nombre
+        form.apellido.data = _usuario.apellido
+        form.correo_electronico.data = _usuario.correo_electronico
+        if coupon_code:
+            coupon_form.coupon_code.data = coupon_code
 
     if form.validate_on_submit():
         pago = _build_pago_from_form(form, _curso, pricing.final_price)

--- a/tests/test_paypal_coupons_flow.py
+++ b/tests/test_paypal_coupons_flow.py
@@ -201,3 +201,34 @@ class TestPayPalCouponFlow:
         # Verify another payment was NOT created
         all_payments = db_session.execute(database.select(Pago).filter_by(usuario=student.usuario, curso=curso.codigo)).scalars().all()
         assert len(all_payments) == 1
+
+    def test_post_enrollment_preserves_custom_details(self, app, client, db_session):
+        student = _crear_estudiante(db_session)
+        curso = _crear_curso_pagado(db_session)
+
+        _login(client, student.usuario, "password")
+
+        # POST to enroll with custom billing details (nombre, apellido, correo_electronico)
+        custom_data = {
+            "nombre": "CustomName",
+            "apellido": "CustomSurname",
+            "correo_electronico": "custom_email@example.com",
+            "direccion1": "Custom Street 1",
+            "pais": "Costa Rica",
+            "provincia": "San Jose",
+            "codigo_postal": "10101",
+            "modo": "paid"
+        }
+
+        resp = client.post(f"/course/{curso.codigo}/enroll", data=custom_data, follow_redirects=False)
+
+        # Should redirect to payment page
+        assert resp.status_code == 302
+        assert f"/paypal_checkout/payment/{curso.codigo}" in resp.location
+
+        # Verify that the created pending Pago has our CUSTOM details rather than defaults
+        pago = db_session.execute(database.select(Pago).filter_by(usuario=student.usuario, curso=curso.codigo, estado="pending")).scalars().first()
+        assert pago is not None
+        assert pago.nombre == "CustomName"
+        assert pago.apellido == "CustomSurname"
+        assert pago.correo_electronico == "custom_email@example.com"


### PR DESCRIPTION
Fixes an issue where custom details/billing inputs submitted by users during the checkout process were unconditionally overwritten with the database default profile values, even during POST submissions or validation errors. Wrapped the pre-fill logic in a GET check and added a robust unit test to prevent regression.

---
*PR created automatically by Jules for task [792008913181704313](https://jules.google.com/task/792008913181704313) started by @williamjmorenor*