### PR TITLE
Fix blog tag and comment deletion flows

### DIFF
--- a/now_lms/templates/blog/admin_tags.html
+++ b/now_lms/templates/blog/admin_tags.html
@@ -36,12 +36,17 @@
                                         <td><code>{{ tag.slug }}</code></td>
                                         <td>{{ tag.posts | length }}</td>
                                         <td>
-                                            <a
-                                                class="badge text-bg-danger"
-                                                href="{{ url_for('blog.delete_tag', tag_id=tag.id) }}"
+                                            <form
+                                                action="{{ url_for('blog.delete_tag', tag_id=tag.id) }}"
+                                                method="POST"
+                                                class="d-inline"
+                                                onsubmit="return confirm('{{ _('¿Está seguro de que desea eliminar esta etiqueta?') }}')"
                                             >
-                                                {{ _('Eliminar') }}
-                                            </a>
+                                                {{ form.csrf_token }}
+                                                <button type="submit" class="badge text-bg-danger border-0">
+                                                    {{ _('Eliminar') }}
+                                                </button>
+                                            </form>
                                         </td>
                                     </tr>
                                     {% endfor %}

--- a/now_lms/templates/blog/post_detail.html
+++ b/now_lms/templates/blog/post_detail.html
@@ -213,9 +213,10 @@
                                                     </li>
                                                     <li>
                                                         <form
-                                                            method="DELETE"
+                                                            method="POST"
                                                             action="{{ url_for('blog.delete_comment', comment_id=comment.id) }}"
                                                             class="d-inline"
+                                                            onsubmit="return confirm('{{ _('¿Está seguro de que desea eliminar este comentario?') }}')"
                                                         >
                                                             <button type="submit" class="dropdown-item text-danger">
                                                                 <i class="fas fa-trash"></i> {{ _('Eliminar') }}

--- a/now_lms/vistas/blog.py
+++ b/now_lms/vistas/blog.py
@@ -512,10 +512,10 @@ def create_tag() -> str | Response:
     return redirect(url_for("blog.admin_tags"))
 
 
-@blog.route("/admin/blog/tags/<tag_id>", methods=["DELETE"])
+@blog.route("/admin/blog/tags/<tag_id>/delete", methods=["POST"])
 @login_required
 @perfil_requerido("admin")
-def delete_tag(tag_id: int) -> Response:
+def delete_tag(tag_id: str) -> Response:
     """Delete a blog tag."""
     tag = database.session.get(BlogTag, tag_id)
     if not tag:
@@ -560,7 +560,7 @@ def ban_comment(comment_id: str) -> str | Response:
     return redirect(url_for(ROUTE_BLOG_POST, slug=comment.post.slug))
 
 
-@blog.route("/admin/blog/comments/<comment_id>", methods=["DELETE"])
+@blog.route("/admin/blog/comments/<comment_id>/delete", methods=["POST"])
 @login_required
 @perfil_requerido("admin")
 def delete_comment(comment_id: str) -> str | Response:

--- a/tests/test_end_to_end_blog.py
+++ b/tests/test_end_to_end_blog.py
@@ -233,3 +233,65 @@ def test_e2e_blog_post_list_admin(app, db_session):
     assert resp_list.status_code == 200
     # Verificar que la página carga correctamente
     assert b"blog" in resp_list.data.lower() or b"post" in resp_list.data.lower()
+
+
+def test_e2e_blog_tag_deletion(app, db_session):
+    """Test: eliminar una etiqueta de blog mediante la nueva ruta POST."""
+    # 1) Crear admin y login
+    _crear_admin(db_session)
+    client = _login_admin(app)
+
+    # 2) Crear un tag de blog directamente en base de datos
+    tag = BlogTag(name="TestTagToDelete", slug="testtagtodelete")
+    db_session.add(tag)
+    db_session.commit()
+    tag_id = tag.id
+
+    # 3) Enviar petición POST para eliminar la etiqueta
+    resp_delete = client.post(f"/admin/blog/tags/{tag_id}/delete", follow_redirects=True)
+    assert resp_delete.status_code == 200
+
+    # 4) Verificar que fue eliminada
+    tag_eliminado = db_session.get(BlogTag, tag_id)
+    assert tag_eliminado is None
+
+
+def test_e2e_blog_comment_deletion_and_banning(app, db_session):
+    """Test: banear y eliminar un comentario de blog mediante rutas POST."""
+    # 1) Crear admin y login
+    admin = _crear_admin(db_session)
+    client = _login_admin(app)
+
+    # 2) Crear post y comentario en base de datos
+    post = BlogPost(
+        title="Post Comentarios",
+        content="Contenido",
+        status="published",
+        slug="post-comentarios",
+        author_id=admin.id,
+    )
+    db_session.add(post)
+    db_session.commit()
+
+    comment = BlogComment(
+        post_id=post.id,
+        user_id=admin.usuario,
+        content="Comentario de prueba",
+        status="visible",
+    )
+    db_session.add(comment)
+    db_session.commit()
+    comment_id = comment.id
+
+    # 3) Banear comentario mediante POST
+    resp_ban = client.post(f"/admin/blog/comments/{comment_id}/ban", follow_redirects=True)
+    assert resp_ban.status_code == 200
+    comment_db = db_session.get(BlogComment, comment_id)
+    assert comment_db is not None
+    assert comment_db.status == "banned"
+
+    # 4) Eliminar comentario mediante POST
+    resp_delete = client.post(f"/admin/blog/comments/{comment_id}/delete", follow_redirects=True)
+    assert resp_delete.status_code == 200
+    comment_eliminado = db_session.get(BlogComment, comment_id)
+    assert comment_eliminado is None


### PR DESCRIPTION
Resolves '405 Method Not Allowed' errors when deleting blog tags or comments. Changing browser-unsupported DELETE or GET methods to secure POST forms ensures full compatibility and standard-compliant functionality. Adds E2E integration tests to cover the deletion flows and prevent future regressions.

---
*PR created automatically by Jules for task [15596052794456963675](https://jules.google.com/task/15596052794456963675) started by @williamjmorenor*