### PR TITLE
Fix Gunicorn Multi-Thread Session Loss via App Preloading and DB Setup

### DIFF
--- a/now_lms/__init__.py
+++ b/now_lms/__init__.py
@@ -639,6 +639,18 @@ def initial_setup(with_examples=False, with_tests=False, flask_app=None):
     with app_to_use.app_context():
         log.info("Creating database schema.")
         database.create_all()
+
+        # Verify that the session tables are established if Flask-Session is using SQLAlchemy
+        if app_to_use.config.get("SESSION_TYPE") == "sqlalchemy":
+            from sqlalchemy import inspect
+            inspector = inspect(database.engine)
+            existing_tables = inspector.get_table_names()
+            session_table = app_to_use.config.get("SESSION_SQLALCHEMY_TABLE", "flask_sessions")
+            if session_table not in existing_tables:
+                log.error(f"Required session table '{session_table}' was not created during bootstrap!")
+                raise RuntimeError(f"Required session table '{session_table}' is missing.")
+            log.info(f"Verified that session table '{session_table}' exists in database schema.")
+
         system_info(app_to_use)
         log.debug("Database schema created successfully.")
         log.debug("Loading sample data.")

--- a/now_lms/cli.py
+++ b/now_lms/cli.py
@@ -400,10 +400,11 @@ def serve(wsgi_server):
                     "workers": WORKERS,
                     "threads": THREADS,
                     "worker_class": "gthread" if THREADS > 1 else "sync",
-                    # Do not fork with SQLAlchemy connections opened by the
-                    # server-side session backend. Session data is shared by
-                    # Redis/the database, while engines remain worker-local.
-                    "preload_app": False,
+                    # Preload the application to ensure that the shared session
+                    # storage and database connections/tables are fully established
+                    # in the master process before worker processes and threads are created.
+                    # This prevents session loss and initialization race conditions across threads.
+                    "preload_app": True,
                     "post_fork": reset_connections_after_fork,
                     "timeout": 120,
                     "graceful_timeout": 30,

--- a/now_lms/session_config.py
+++ b/now_lms/session_config.py
@@ -169,16 +169,6 @@ def init_session(app: Flask) -> None:
         Session(app)
         if session_config.get("SESSION_TYPE") == "sqlalchemy":
             _session_model_created = True
-            # Establish the database connection and verify/create session tables
-            # before any worker processes and threads are created.
-            from now_lms.db import database
-            with app.app_context():
-                try:
-                    database.create_all()
-                    log.info("SQLAlchemy database connection established and session tables verified.")
-                except Exception as e:
-                    log.error(f"Failed to establish database connection or verify session tables: {e}")
-                    raise
 
         # Configuration alone is not proof that Flask-Session took control.
         # A previous implementation could catch an initialization error and

--- a/now_lms/session_config.py
+++ b/now_lms/session_config.py
@@ -169,6 +169,16 @@ def init_session(app: Flask) -> None:
         Session(app)
         if session_config.get("SESSION_TYPE") == "sqlalchemy":
             _session_model_created = True
+            # Establish the database connection and verify/create session tables
+            # before any worker processes and threads are created.
+            from now_lms.db import database
+            with app.app_context():
+                try:
+                    database.create_all()
+                    log.info("SQLAlchemy database connection established and session tables verified.")
+                except Exception as e:
+                    log.error(f"Failed to establish database connection or verify session tables: {e}")
+                    raise
 
         # Configuration alone is not proof that Flask-Session took control.
         # A previous implementation could catch an initialization error and

--- a/run.py
+++ b/run.py
@@ -66,10 +66,11 @@ if init_app():
                     "workers": workers,
                     "threads": threads,
                     "worker_class": "gthread" if threads > 1 else "sync",
-                    # The application is constructed before embedded Gunicorn
-                    # starts. The post-fork hook below is therefore the
-                    # authoritative protection against inherited connections.
-                    "preload_app": False,
+                    # Preload the application to ensure that the shared session
+                    # storage and database connections/tables are fully established
+                    # in the master process before worker processes and threads are created.
+                    # This prevents session loss and initialization race conditions across threads.
+                    "preload_app": True,
                     "post_fork": reset_connections_after_fork,
                     "timeout": 120,
                     "graceful_timeout": 30,

--- a/tests/test_session_multiworker.py
+++ b/tests/test_session_multiworker.py
@@ -123,36 +123,64 @@ def test_init_session_sqlalchemy_success(monkeypatch):
 
     init_session(app)
 
+    # Should run successfully and set session configuration
+    assert app.config.get("SESSION_TYPE") == "sqlalchemy"
+
+
+def test_initial_setup_session_table_verification_success(monkeypatch):
+    from flask import Flask
+    from now_lms import initial_setup
+    from unittest.mock import MagicMock
+
+    app = Flask("test_app")
+    app.config["TESTING"] = False
+    app.config["SESSION_TYPE"] = "sqlalchemy"
+    app.config["SESSION_SQLALCHEMY_TABLE"] = "flask_sessions"
+
+    mock_db = MagicMock()
+    monkeypatch.setattr("now_lms.database", mock_db)
+    monkeypatch.setattr("now_lms.db.database", mock_db)
+
+    mock_inspector = MagicMock()
+    mock_inspector.get_table_names.return_value = ["flask_sessions"]
+    monkeypatch.setattr("sqlalchemy.inspect", lambda engine: mock_inspector)
+
+    monkeypatch.setattr("now_lms.system_info", MagicMock())
+    monkeypatch.setattr("now_lms.crear_configuracion_predeterminada", MagicMock())
+    monkeypatch.setattr("now_lms.crear_certificados", MagicMock())
+    monkeypatch.setattr("now_lms.crear_curso_predeterminado", MagicMock())
+    monkeypatch.setattr("now_lms.crear_curso_autoaprendizaje", MagicMock())
+    monkeypatch.setattr("now_lms.crear_evaluacion_predeterminada", MagicMock())
+    monkeypatch.setattr("now_lms.crear_usuarios_predeterminados", MagicMock())
+    monkeypatch.setattr("now_lms.crear_certificacion", MagicMock())
+    monkeypatch.setattr("now_lms.crear_blog_post_predeterminado", MagicMock())
+    monkeypatch.setattr("now_lms.crear_paginas_estaticas_predeterminadas", MagicMock())
+    monkeypatch.setattr("now_lms.populate_custmon_data_dir", MagicMock())
+    monkeypatch.setattr("now_lms.populate_custom_theme_dir", MagicMock())
+
+    initial_setup(flask_app=app)
+
     mock_db.create_all.assert_called_once()
 
 
-def test_init_session_sqlalchemy_failure(monkeypatch):
+def test_initial_setup_session_table_verification_failure(monkeypatch):
     from flask import Flask
-    from now_lms.session_config import init_session
+    from now_lms import initial_setup
     from unittest.mock import MagicMock
-    from flask_session.base import ServerSideSessionInterface
     import pytest
 
     app = Flask("test_app")
     app.config["TESTING"] = False
-    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
-    monkeypatch.delenv("CACHE_REDIS_URL", raising=False)
-    monkeypatch.delenv("REDIS_URL", raising=False)
+    app.config["SESSION_TYPE"] = "sqlalchemy"
+    app.config["SESSION_SQLALCHEMY_TABLE"] = "flask_sessions"
 
     mock_db = MagicMock()
-    mock_db.create_all.side_effect = Exception("mock database error")
-
-    import now_lms.session_config
-    monkeypatch.setattr(now_lms.session_config, "get_session_config", lambda app: {
-        "SESSION_TYPE": "sqlalchemy",
-        "SESSION_SQLALCHEMY_TABLE": "flask_sessions",
-    })
-
+    monkeypatch.setattr("now_lms.database", mock_db)
     monkeypatch.setattr("now_lms.db.database", mock_db)
 
-    mock_session_cls = MagicMock()
-    monkeypatch.setattr("flask_session.Session", mock_session_cls)
-    app.session_interface = MagicMock(spec=ServerSideSessionInterface)
+    mock_inspector = MagicMock()
+    mock_inspector.get_table_names.return_value = []
+    monkeypatch.setattr("sqlalchemy.inspect", lambda engine: mock_inspector)
 
-    with pytest.raises(Exception, match="mock database error"):
-        init_session(app)
+    with pytest.raises(RuntimeError, match="Required session table 'flask_sessions' is missing."):
+        initial_setup(flask_app=app)

--- a/tests/test_session_multiworker.py
+++ b/tests/test_session_multiworker.py
@@ -93,3 +93,66 @@ def test_gunicorn_postfork_discards_inherited_database_pool(monkeypatch):
     reset_connections_after_fork(None, SimpleNamespace(pid=1234))
 
     dispose.assert_called_once_with(close=False)
+
+
+def test_init_session_sqlalchemy_success(monkeypatch):
+    from flask import Flask
+    from now_lms.session_config import init_session
+    from unittest.mock import MagicMock
+    from flask_session.base import ServerSideSessionInterface
+
+    app = Flask("test_app")
+    app.config["TESTING"] = False
+    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
+    monkeypatch.delenv("CACHE_REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    mock_db = MagicMock()
+
+    import now_lms.session_config
+    monkeypatch.setattr(now_lms.session_config, "get_session_config", lambda app: {
+        "SESSION_TYPE": "sqlalchemy",
+        "SESSION_SQLALCHEMY_TABLE": "flask_sessions",
+    })
+
+    monkeypatch.setattr("now_lms.db.database", mock_db)
+
+    mock_session_cls = MagicMock()
+    monkeypatch.setattr("flask_session.Session", mock_session_cls)
+    app.session_interface = MagicMock(spec=ServerSideSessionInterface)
+
+    init_session(app)
+
+    mock_db.create_all.assert_called_once()
+
+
+def test_init_session_sqlalchemy_failure(monkeypatch):
+    from flask import Flask
+    from now_lms.session_config import init_session
+    from unittest.mock import MagicMock
+    from flask_session.base import ServerSideSessionInterface
+    import pytest
+
+    app = Flask("test_app")
+    app.config["TESTING"] = False
+    monkeypatch.delenv("SESSION_REDIS_URL", raising=False)
+    monkeypatch.delenv("CACHE_REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    mock_db = MagicMock()
+    mock_db.create_all.side_effect = Exception("mock database error")
+
+    import now_lms.session_config
+    monkeypatch.setattr(now_lms.session_config, "get_session_config", lambda app: {
+        "SESSION_TYPE": "sqlalchemy",
+        "SESSION_SQLALCHEMY_TABLE": "flask_sessions",
+    })
+
+    monkeypatch.setattr("now_lms.db.database", mock_db)
+
+    mock_session_cls = MagicMock()
+    monkeypatch.setattr("flask_session.Session", mock_session_cls)
+    app.session_interface = MagicMock(spec=ServerSideSessionInterface)
+
+    with pytest.raises(Exception, match="mock database error"):
+        init_session(app)


### PR DESCRIPTION
Fixes session loss issues when running Gunicorn in multi-threaded/multi-process mode. The application is preloaded (`preload_app: True`) in the Gunicorn master process, and database connections/session tables are verified and established before threads are created.

---
*PR created automatically by Jules for task [13368510882011037763](https://jules.google.com/task/13368510882011037763) started by @williamjmorenor*