### PR TITLE
Correct Certification Filtering in Student Profile View

### DIFF
--- a/now_lms/vistas/profiles/user.py
+++ b/now_lms/vistas/profiles/user.py
@@ -80,7 +80,7 @@ def perfil() -> str | Response:
         certificaciones_query = database.session.execute(
             database.select(Certificacion, Curso)
             .join(Curso, Certificacion.curso == Curso.codigo)
-            .filter(Certificacion.usuario == current_user.id)
+            .filter(Certificacion.usuario == current_user.usuario)
         ).fetchall()
         certificaciones = [{"certificacion": cert[0], "curso": cert[1]} for cert in certificaciones_query]
 

--- a/tests/test_user_profiles.py
+++ b/tests/test_user_profiles.py
@@ -88,7 +88,7 @@ def test_perfil_student(client_student, db_session, profile_users):
 
     # Create a certification
     cert = Certificacion(
-        usuario=profile_users["student"].id,
+        usuario=profile_users["student"].usuario,
         curso="PROF101",
         certificado="default",
     )
@@ -99,6 +99,9 @@ def test_perfil_student(client_student, db_session, profile_users):
     resp = client_student.get("/perfil")
     assert resp.status_code == 200
     assert b"Test Course For Profile" in resp.data
+    # Assert that the certifications list is populated and contains the cert information
+    assert b"Mis Certificaciones" in resp.data
+    assert b"No tienes certificaciones obtenidas" not in resp.data
 
 
 def test_perfil_instructor(client, profile_users, app):


### PR DESCRIPTION
Correct certification filtering in student profile view by querying on `current_user.usuario` rather than `current_user.id`, aligning with the database schema where Certificacion.usuario stores the username/email.

---
*PR created automatically by Jules for task [102901173978988354](https://jules.google.com/task/102901173978988354) started by @williamjmorenor*