### PR TITLE
Fix Nonexistent User Profile Access and Template Corruptions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,12 @@ now_lms/templates/blog/post_detail.html
 # Templates with Jinja2 variables in CSS
 now_lms/templates/learning/my_courses.html
 
+# Templates with Jinja2 variables in HTML attributes/logic that get corrupted by Prettier
+now_lms/templates/admin/contact_messages.html
+now_lms/templates/admin/view_contact_message.html
+now_lms/templates/admin/payments.html
+now_lms/templates/inicio/panel_admin.html
+
 
 # General patterns for build and dependency files
 node_modules/

--- a/now_lms/__init__.py
+++ b/now_lms/__init__.py
@@ -643,6 +643,7 @@ def initial_setup(with_examples=False, with_tests=False, flask_app=None):
         # Verify that the session tables are established if Flask-Session is using SQLAlchemy
         if app_to_use.config.get("SESSION_TYPE") == "sqlalchemy":
             from sqlalchemy import inspect
+
             inspector = inspect(database.engine)
             existing_tables = inspector.get_table_names()
             session_table = app_to_use.config.get("SESSION_SQLALCHEMY_TABLE", "flask_sessions")

--- a/now_lms/vistas/profiles/user.py
+++ b/now_lms/vistas/profiles/user.py
@@ -109,6 +109,8 @@ def perfil() -> str | Response:
 def usuario(id_usuario: str) -> str:
     """Acceso administrativo al perfil de un usuario."""
     perfil_usuario = database.session.execute(database.select(Usuario).filter_by(usuario=id_usuario)).scalar_one_or_none()
+    if perfil_usuario is None:
+        abort(404)
     # La misma plantilla del perfil de usuario con permisos elevados como
     # activar desactivar el perfil o cambiar el perfil del usuario.
     if current_user.usuario == id_usuario or current_user.tipo != "student" or perfil_usuario.visible is True:

--- a/tests/test_user_profiles.py
+++ b/tests/test_user_profiles.py
@@ -129,6 +129,12 @@ def test_view_other_users(client_student, profile_users):
     assert b"private" in resp_priv.data or b"privado" in resp_priv.data.lower()
 
 
+def test_view_nonexistent_user(client_student):
+    """Test viewing a nonexistent user's profile returns 404."""
+    resp = client_student.get("/user/nonexistent_user_123456")
+    assert resp.status_code == 404
+
+
 def test_edit_perfil(client_student, profile_users, db_session):
     """Test editing profile via GET and POST."""
     student_id = profile_users["student"].id


### PR DESCRIPTION
Fixes a 500 error on the `/user/<id_usuario>` profile route when accessing a nonexistent username, and prevents automated formatter corruption of templates.

---
*PR created automatically by Jules for task [6150535151362661525](https://jules.google.com/task/6150535151362661525) started by @williamjmorenor*