### PR TITLE
Fix blog post comment count double-counting bug

### DIFF
--- a/now_lms/vistas/blog.py
+++ b/now_lms/vistas/blog.py
@@ -175,7 +175,7 @@ def add_comment(slug: str) -> Response:
                 and_(BlogComment.post_id == post.id, BlogComment.status == "visible")
             )
         ).scalar()
-        post.comment_count = (result or 0) + 1
+        post.comment_count = result or 0
 
         database.session.commit()
 

--- a/tests/test_end_to_end_blog.py
+++ b/tests/test_end_to_end_blog.py
@@ -149,6 +149,10 @@ def test_e2e_blog_comments(app, db_session):
     assert comentario.content == "Este es un comentario de prueba"
     assert comentario.user_id == admin.usuario  # user_id es el nombre de usuario, no el ID
 
+    # Verify post comment_count
+    post_db = db_session.get(BlogPost, post_id)
+    assert post_db.comment_count == 1
+
 
 def test_e2e_blog_tags(app, db_session):
     """Test: crear y usar tags de blog."""


### PR DESCRIPTION
Fixes an off-by-one double-counting bug in the `add_comment` view where `post.comment_count` was set to `query_count + 1`. Since the database query triggers SQLAlchemy's autoflush, the newly added comment is already counted in the query result. The change sets `post.comment_count` directly to the query result and adds a test assertion verifying correct comment counting behavior.

---
*PR created automatically by Jules for task [8745395102821998624](https://jules.google.com/task/8745395102821998624) started by @williamjmorenor*