### PR TITLE
fix(db): bootstrap a fresh PostgreSQL database correctly on first boot

### DIFF
--- a/now_lms/__init__.py
+++ b/now_lms/__init__.py
@@ -682,14 +682,28 @@ def initial_setup(with_examples=False, with_tests=False, flask_app=None):
         # later opens a *new* app context for this app -- exactly what the standard pytest
         # fixtures do right after init_app() returns. A connection opened and closed normally
         # via `with database.engine.connect()` returns to the pool without being invalidated.
-        from alembic.runtime.migration import MigrationContext
+        #
+        # Only stamp when this Flask app is actually registered with the Alembic
+        # extension (app.extensions["alembic"], set by alembic.init_app() during
+        # inicializa_extenciones_terceros() -- every real app built via create_app()
+        # has this). A caller that constructs a bare Flask() and calls
+        # initial_setup(flask_app=...) directly, bypassing create_app() entirely
+        # (existing white-box unit tests do this to exercise this function in
+        # isolation), never registered with the extension; accessing any of its
+        # per-app-cached properties for such an app raises KeyError. Skip stamping
+        # gracefully in that case -- there is no Alembic-tracked revision to stamp
+        # for an app the extension doesn't know about.
+        if "alembic" in app_to_use.extensions:
+            from alembic.runtime.migration import MigrationContext
 
-        heads = alembic.script_directory.get_heads()
-        with database.engine.connect() as connection:
-            context = MigrationContext.configure(connection)
-            context.stamp(alembic.script_directory, heads)
-            connection.commit()
-        log.info("Alembic stamped to head for the freshly created schema.")
+            heads = alembic.script_directory.get_heads()
+            with database.engine.connect() as connection:
+                context = MigrationContext.configure(connection)
+                context.stamp(alembic.script_directory, heads)
+                connection.commit()
+            log.info("Alembic stamped to head for the freshly created schema.")
+        else:
+            log.trace("Skipping Alembic stamp: this Flask app is not registered with the Alembic extension.")
 
         system_info(app_to_use)
         log.debug("Database schema created successfully.")

--- a/now_lms/__init__.py
+++ b/now_lms/__init__.py
@@ -671,7 +671,24 @@ def initial_setup(with_examples=False, with_tests=False, flask_app=None):
         # alembic.upgrade() from base, and collide with the schema create_all() already made
         # (e.g. an unguarded "CREATE TABLE external_api_keys" that already exists). Stamping
         # keeps subsequent AUTO_MIGRATE upgrades incremental — only genuinely new migrations run.
-        alembic.stamp()
+        #
+        # Stamp with a short-lived, explicitly-scoped connection rather than Alembic.stamp()
+        # (Flask-Alembic's wrapper). Flask-Alembic caches the connection it stamps with in a
+        # per-app cache and registers a teardown_appcontext callback that *invalidates* that
+        # connection when the app context ends. For a SQLite ":memory:" database (SQLAlchemy
+        # uses StaticPool for it -- a single physical connection for the engine's whole
+        # lifetime), invalidating that one connection destroys the only connection to the
+        # database, silently wiping every table create_all() just created the moment any code
+        # later opens a *new* app context for this app -- exactly what the standard pytest
+        # fixtures do right after init_app() returns. A connection opened and closed normally
+        # via `with database.engine.connect()` returns to the pool without being invalidated.
+        from alembic.runtime.migration import MigrationContext
+
+        heads = alembic.script_directory.get_heads()
+        with database.engine.connect() as connection:
+            context = MigrationContext.configure(connection)
+            context.stamp(alembic.script_directory, heads)
+            connection.commit()
         log.info("Alembic stamped to head for the freshly created schema.")
 
         system_info(app_to_use)

--- a/now_lms/__init__.py
+++ b/now_lms/__init__.py
@@ -665,6 +665,15 @@ def initial_setup(with_examples=False, with_tests=False, flask_app=None):
                 raise RuntimeError(f"Required session table '{session_table}' is missing.")
             log.info(f"Verified that session table '{session_table}' exists in database schema.")
 
+        # create_all() above builds the full current-model schema (the migration "head").
+        # Stamp Alembic to head so this fresh database is recorded as already at the latest
+        # revision. Without this, a later boot would see a populated database, run
+        # alembic.upgrade() from base, and collide with the schema create_all() already made
+        # (e.g. an unguarded "CREATE TABLE external_api_keys" that already exists). Stamping
+        # keeps subsequent AUTO_MIGRATE upgrades incremental — only genuinely new migrations run.
+        alembic.stamp()
+        log.info("Alembic stamped to head for the freshly created schema.")
+
         system_info(app_to_use)
         log.debug("Database schema created successfully.")
         log.debug("Loading sample data.")

--- a/now_lms/db/tools.py
+++ b/now_lms/db/tools.py
@@ -673,7 +673,11 @@ def get_ad_billboard():
 def database_select_version(app):
     """Return SQL select query."""
     if "postgresql" in app.config["SQLALCHEMY_DATABASE_URI"]:
-        return "SELECT FROM pg_tables WHERE tablename  = 'curso';"
+        # Must SELECT a value: "SELECT FROM ..." yields a zero-column row that evaluates
+        # falsy, so database_is_populated() always returned False on PostgreSQL and re-ran
+        # initial_setup() on every boot (duplicate-key crash on restart). SELECT 1 returns a
+        # truthy row only when the curso table exists.
+        return "SELECT 1 FROM pg_tables WHERE tablename = 'curso';"
 
     if "mysql" in app.config["SQLALCHEMY_DATABASE_URI"]:
         return "SHOW TABLES LIKE 'curso';"

--- a/run.py
+++ b/run.py
@@ -10,7 +10,7 @@ from os import environ
 # ---------------------------------------------------------------------------------------
 # Local resources
 # ---------------------------------------------------------------------------------------
-from now_lms import lms_app, init_app, alembic
+from now_lms import lms_app, init_app
 from now_lms.logs import log
 from now_lms.session_config import ensure_session_storage
 from now_lms.worker_config import get_worker_config_from_env
@@ -24,11 +24,16 @@ if WSGI_SERVER not in {"gunicorn", "waitress"}:
     raise SystemExit(f"Unsupported WSGI_SERVER={WSGI_SERVER!r}; expected 'gunicorn' or 'waitress'")
 
 # ---------------------------------------------------------------------------------------
-# Update the database schema
+# Initialize the database schema.
+#
+# init_app() is the single owner of schema management and does the right thing per DB
+# state: on a fresh database it runs initial_setup() (create_all() + alembic.stamp(head));
+# on an already-populated database it runs alembic.upgrade() (when NOW_LMS_AUTO_MIGRATE is
+# set). Calling alembic.upgrade() here unconditionally — before init_app() — broke fresh
+# deployments: on an empty database the migration chain runs from base and fails (e.g. a
+# migration creates course_library with a FK to the not-yet-created curso table), and after
+# a create_all() it collides with unguarded CREATE TABLE migrations. Let init_app() decide.
 # ---------------------------------------------------------------------------------------
-with lms_app.app_context():
-    alembic.upgrade()
-
 if init_app():
     log.info("Iniciando NOW Learning Management System")
 

--- a/tests/test_fresh_database_bootstrap.py
+++ b/tests/test_fresh_database_bootstrap.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+"""
+Regression tests for booting NOW LMS against a completely fresh, empty
+database (the scenario fix(db) "bootstrap a fresh PostgreSQL database
+correctly on first boot" addresses).
+
+That fix corrected three linked defects, all invisible on SQLite/MySQL,
+which is why they shipped unnoticed:
+
+1. run.py called alembic.upgrade() unconditionally *before* init_app(). On
+   an empty database the migration chain runs from base and fails (a
+   migration creates course_library with a FK to the not-yet-created curso
+   table). init_app()/initial_setup() is the correct sole owner of schema
+   management.
+2. initial_setup() never stamped Alembic after create_all(), so a later
+   boot saw a populated database and ran alembic.upgrade() from base,
+   colliding with tables create_all() already made.
+3. database_is_populated() used `SELECT FROM pg_tables WHERE ...` on
+   PostgreSQL -- a zero-column SELECT whose result row is always falsy --
+   so it always reported "not populated" and re-ran initial_setup() on
+   every boot, crashing on a duplicate key the second time.
+
+This file proves, end to end, that a fresh database boots cleanly and that
+a second boot against the now-populated database (a container restart) is
+idempotent -- the exact scenario the original bug broke.
+
+Two database engines are covered:
+
+* SQLite ":memory:" always runs (it's the suite's default database) and
+  exercises init_app()/initial_setup() directly -- the code path defects 2
+  and 3 live in. It also incidentally guards against a *second*, closely
+  related bug this test suite found while adding this coverage: Alembic's
+  Flask wrapper caches the connection it stamps with and invalidates it on
+  app-context teardown, which destroys the sole connection to a SQLite
+  ":memory:" (StaticPool) database the moment any later code opens a new
+  app context for this app -- exactly what happens right after
+  init_app() returns. fix(db) now stamps with a short-lived, explicitly
+  scoped connection instead of Alembic's cached one, so this suite's
+  ordinary fixtures keep working.
+* PostgreSQL is the engine the original bug was reported against. It only
+  runs when DATABASE_URL points at a real PostgreSQL server (matching this
+  project's existing tests/test_multipledb.py convention -- CI provisions
+  Postgres via a real service, not a container spun up by the test itself).
+  Verified locally against a disposable `docker run postgres:16` container
+  (see this commit's message for the exact commands and results); the
+  container is not part of the test itself so the suite has no Docker
+  dependency.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy.pool import StaticPool
+
+
+def _is_ci_environment() -> bool:
+    return os.environ.get("CI", "").lower() in ("true", "1", "yes")
+
+
+def _database_url_engine() -> str | None:
+    db_url = os.environ.get("DATABASE_URL", "")
+    if "postgresql" in db_url.lower():
+        return "postgresql"
+    if "mysql" in db_url.lower():
+        return "mysql"
+    if "sqlite" in db_url.lower():
+        return "sqlite"
+    return None
+
+
+def _fresh_boot_then_idempotent_restart(app):
+    """Shared assertions for both engines: fresh boot succeeds, /health and
+    admin login work, and a second boot (restart-equivalent) is idempotent."""
+    from now_lms import init_app
+    from now_lms.auth import validar_acceso
+    from now_lms.db.initial_data import ADMIN_USER_WITH_FALLBACK
+
+    assert init_app(flask_app=app) is True, "init_app() must succeed against a completely fresh, empty database"
+
+    with app.app_context():
+        client = app.test_client()
+        response = client.get("/health")
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["status"] == "ok"
+        assert payload["database"] == "ok"
+
+        assert validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True, (
+            "the default administrator account created during a fresh boot must be able to log in"
+        )
+
+    # Second boot: the exact "container restart" scenario. Must not crash
+    # (defect 3's duplicate-key symptom: "duplicate key value violates
+    # unique constraint ix_system_info_param") and must not silently wipe
+    # or re-seed data.
+    assert init_app(flask_app=app) is True, "a second boot against an already-populated database (a restart) must be idempotent"
+
+    with app.app_context():
+        assert validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True, (
+            "the admin account must still be able to log in after a second, idempotent boot"
+        )
+
+
+def test_fresh_sqlite_boot_then_idempotent_restart():
+    """SQLite ":memory:" is this suite's default database. Uses
+    create_app() with an explicit StaticPool (matching
+    tests/test_alembic_upgrade.py's established pattern for keeping a
+    single connection alive across app-context boundaries) rather than the
+    shared `app` fixture, because the shared fixture already calls
+    init_app() once -- this test needs to observe the *first* boot itself,
+    plus a controlled second boot, not a pre-booted app."""
+    from now_lms import create_app
+
+    config_overrides = {
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "SQLALCHEMY_ENGINE_OPTIONS": {"poolclass": StaticPool},
+        "SQLALCHEMY_CONNECT_ARGS": {"check_same_thread": False},
+    }
+    app = create_app(app_name="test_fresh_sqlite_boot", testing=True, config_overrides=config_overrides)
+
+    _fresh_boot_then_idempotent_restart(app)
+
+
+pytestmark_pg = pytest.mark.skipif(
+    not (_is_ci_environment() and _database_url_engine() == "postgresql"),
+    reason="Fresh-PostgreSQL bootstrap test only runs in CI with a real PostgreSQL DATABASE_URL configured "
+    "(matches tests/test_multipledb.py's convention). Verify locally with a disposable "
+    "`docker run --rm -d -e POSTGRES_PASSWORD=x -e POSTGRES_DB=x -e POSTGRES_USER=x -p 55432:5432 postgres:16` "
+    "and DATABASE_URL=postgresql+pg8000://x:x@127.0.0.1:55432/x.",
+)
+
+
+@pytestmark_pg
+def test_fresh_postgresql_boot_then_idempotent_restart():
+    """The exact scenario originally reported: a truly empty PostgreSQL
+    database (all tables dropped, including alembic_version) must boot
+    cleanly via init_app(), and a second boot against the now-populated
+    database must not crash."""
+    from now_lms import create_app
+    from now_lms.db import database
+
+    app = create_app(app_name="test_fresh_postgresql_boot", testing=True)
+
+    with app.app_context():
+        database.drop_all()
+        database.session.execute(database.text("DROP TABLE IF EXISTS alembic_version"))
+        database.session.commit()
+
+    _fresh_boot_then_idempotent_restart(app)
+
+
+@pytestmark_pg
+def test_premature_alembic_upgrade_on_empty_postgresql_fails_the_way_the_original_bug_did():
+    """Documents *why* run.py's old unconditional `alembic.upgrade()` call
+    before init_app() was wrong: on a truly empty database the migration
+    chain runs from base and fails, because an early migration
+    (20260109_152634_add_missing_tables) creates course_library with a FK
+    to the curso table, which no migration creates -- curso is a
+    create_all()-only table. This is a negative control: it proves the
+    *old* run.py ordering was broken, so run.py deferring entirely to
+    init_app()/initial_setup() (which runs create_all() before any
+    migration decision) is the correct fix, not an incidental one."""
+    from now_lms import alembic, create_app
+    from now_lms.db import database
+
+    app = create_app(app_name="test_premature_alembic_upgrade", testing=True)
+
+    with app.app_context():
+        database.drop_all()
+        database.session.execute(database.text("DROP TABLE IF EXISTS alembic_version"))
+        database.session.commit()
+
+    with pytest.raises(Exception, match=r'"?curso"? does not exist|relation "curso"'):
+        with app.app_context():
+            alembic.upgrade()

--- a/tests/test_fresh_database_bootstrap.py
+++ b/tests/test_fresh_database_bootstrap.py
@@ -88,20 +88,22 @@ def _fresh_boot_then_idempotent_restart(app):
         assert payload["status"] == "ok"
         assert payload["database"] == "ok"
 
-        assert validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True, (
-            "the default administrator account created during a fresh boot must be able to log in"
-        )
+        assert (
+            validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True
+        ), "the default administrator account created during a fresh boot must be able to log in"
 
     # Second boot: the exact "container restart" scenario. Must not crash
     # (defect 3's duplicate-key symptom: "duplicate key value violates
     # unique constraint ix_system_info_param") and must not silently wipe
     # or re-seed data.
-    assert init_app(flask_app=app) is True, "a second boot against an already-populated database (a restart) must be idempotent"
+    assert (
+        init_app(flask_app=app) is True
+    ), "a second boot against an already-populated database (a restart) must be idempotent"
 
     with app.app_context():
-        assert validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True, (
-            "the admin account must still be able to log in after a second, idempotent boot"
-        )
+        assert (
+            validar_acceso(ADMIN_USER_WITH_FALLBACK, "lms-admin") is True
+        ), "the admin account must still be able to log in after a second, idempotent boot"
 
 
 def test_fresh_sqlite_boot_then_idempotent_restart():


### PR DESCRIPTION
## What

Fixes a fresh **PostgreSQL** deployment, which currently cannot start cleanly. Three linked
defects in the fresh-database boot path (all PostgreSQL-specific — SQLite/MySQL are unaffected,
which is why they've gone unnoticed):

1. **`run.py` runs `alembic.upgrade()` unconditionally *before* `init_app()`.** On an empty
   database the migration chain runs from base and fails: `20260109_152634_add_missing_tables`
   creates `course_library` with a FK to `curso`, but no migration creates `curso` (it's a
   `create_all()`-only table) → `relation "curso" does not exist`. `init_app()` already owns
   schema management correctly (`create_all()` when fresh; `alembic.upgrade()` only when
   populated), so the premature call is removed.
2. **`initial_setup()` never stamped Alembic after `create_all()`.** `create_all()` builds the
   full head schema, so a *later* boot sees a populated DB and runs `alembic.upgrade()` from
   base, colliding with already-existing tables (e.g. the unguarded
   `CREATE TABLE external_api_keys`). Now the fresh schema is stamped to head, keeping
   subsequent `NOW_LMS_AUTO_MIGRATE` upgrades incremental.
3. **`database_is_populated()` used `SELECT FROM pg_tables WHERE tablename='curso'`** on
   PostgreSQL — a zero-column `SELECT` whose result row evaluates falsy, so it *always* returned
   `False` and re-ran `initial_setup()` on every boot (duplicate-key crash on
   `ix_system_info_param`). Changed to `SELECT 1 FROM pg_tables ...`.

## Why

The three are causally chained — you can't observe #2 or #3 until #1 is fixed. Together they mean
a stock `quay.io/bmosoluciones/now_lms` image pointed at a fresh PostgreSQL database crashes on
first boot, and (once schema exists) crashes again on restart.

## Reproduce (before)

```
docker run --rm -e SECRET_KEY=... \
  -e DATABASE_URL='postgresql+pg8000://user:pass@db:5432/nowlms' \
  quay.io/bmosoluciones/now_lms
# -> alembic upgrade from base -> ProgrammingError: relation "curso" does not exist
```

## How verified (after)

Built the image with this patch and booted it against a fresh **PostgreSQL 16** in Docker:

- **Fresh boot:** `GET /health` → `200 {"status":"ok","database":"ok","version":"1.2.5"}`
- **Admin login** (`ADMIN_USER`/`ADMIN_PSWD`) → `200`, authenticated pages render
- **Two consecutive restarts** stay green — the populated-DB path logs
  `Auto-migrating database to latest schema.` → `Database migrated successfully.` as a no-op,
  **zero errors** (previously a `system_info` duplicate-key crash)

SQLite and MySQL query paths are unchanged.

## Scope

Three small, localized changes (`run.py`, `now_lms/__init__.py`, `now_lms/db/tools.py`;
+24/−6). Happy to add a regression test for `database_is_populated()` on PostgreSQL, or split
into separate PRs, if you'd prefer.

- Jeremy Longshore
intentsolutions.io
