### PR TITLE
Add PayPal Payment Receipts and PDF Download History

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### Added:
+ - Payment receipt generation: automatically sends a beautiful HTML receipt via email when PayPal payments are completed (if SMTP is configured).
+ - Student payment history: a new `/payments` dashboard where students can view their transaction history, and download a simple PDF copy of their receipt using Weasyprint.
+
 ## [1.2.4] - 2026-05-12
 
 ### Changed:

--- a/now_lms/templates/inicio/perfil.html
+++ b/now_lms/templates/inicio/perfil.html
@@ -359,6 +359,29 @@
                                 </div>
                             </div>
                         </div>
+
+                        <!-- Student Payments Link -->
+                        <div class="profile-card p-4 mt-4">
+                            <div class="row align-items-center">
+                                <div class="col-md-8">
+                                    <h4 class="mb-2">
+                                        <i class="bi bi-wallet2 text-success me-2"></i>{{ _('Historial de Pagos') }}
+                                    </h4>
+                                    <p class="text-muted mb-0">
+                                        {{ _('Consulta tus transacciones de pago, estados y descarga tus recibos de pago en PDF.') }}
+                                    </p>
+                                </div>
+                                <div class="col-md-4 text-end">
+                                    <a
+                                        href="{{ url_for('user_profile.payments_history') }}"
+                                        class="btn btn-outline-success"
+                                        style="border-radius: 25px"
+                                    >
+                                        <i class="bi bi-file-earmark-text me-1"></i> {{ _('Mis Pagos') }}
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                         {% elif perfil.tipo == "instructor" %}
                         <!-- Instructor Profile Section -->
                         <div class="profile-card p-4 mb-4">

--- a/now_lms/templates/payments/history.html
+++ b/now_lms/templates/payments/history.html
@@ -1,0 +1,115 @@
+{% set current_theme = current_theme() %}
+{% set config = config() %}
+
+<!doctype html>
+<html lang="{{ current_locale() }}" class="h-100">
+    <head>
+        {{ current_theme.headertags() }}
+        {{ current_theme.local_style() }}
+        <title>{{ _('Historial de Pagos') }} - {{ config.sitio_nombre }}</title>
+    </head>
+
+    <body>
+        {{ current_theme.navbar() }}
+
+        <main class="container my-5">
+            {{ current_theme.notify() }}
+
+            <div class="d-flex justify-content-between border-bottom mb-4 pb-2">
+                <h2>
+                    <nav aria-label="{{ _('breadcrumb') }}">
+                        <ol class="breadcrumb mb-0" style="background: none; padding: 0;">
+                            <li class="breadcrumb-item">
+                                <a class="text-reset text-decoration-none" href="{{ url_for('home.panel') }}">{{ _('Inicio') }}</a>
+                            </li>
+                            <li class="breadcrumb-item active" aria-current="page">{{ _('Historial de Pagos') }}</li>
+                        </ol>
+                    </nav>
+                </h2>
+            </div>
+
+            <div class="card shadow-sm border-0" style="border-radius: 12px; overflow: hidden;">
+                <div class="card-header bg-light d-flex align-items-center py-3">
+                    <h5 class="mb-0 text-secondary">
+                        <i class="bi bi-wallet2 me-2 text-primary"></i>
+                        {{ _('Mis Pagos Registrados') }}
+                    </h5>
+                </div>
+                <div class="card-body p-0">
+                    {% if pago_rows %}
+                        <div class="table-responsive">
+                            <table class="table table-hover align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th class="ps-4">{{ _('Curso') }}</th>
+                                        <th>{{ _('Fecha') }}</th>
+                                        <th>{{ _('Monto') }}</th>
+                                        <th>{{ _('ID Transacción') }}</th>
+                                        <th>{{ _('Método') }}</th>
+                                        <th>{{ _('Estado') }}</th>
+                                        <th class="text-end pe-4">{{ _('Acciones') }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for row in pago_rows %}
+                                        <tr>
+                                            <td class="ps-4">
+                                                <div class="fw-bold text-dark">{{ row.curso.nombre if row.curso else row.pago.curso }}</div>
+                                                <small class="text-muted">{{ row.pago.curso }}</small>
+                                            </td>
+                                            <td>
+                                                {{ row.pago.fecha.strftime('%Y-%m-%d %H:%M') if row.pago.fecha else '' }}
+                                            </td>
+                                            <td>
+                                                <span class="fw-bold">{{ row.pago.monto }} {{ row.pago.moneda }}</span>
+                                            </td>
+                                            <td>
+                                                <code class="text-muted small">{{ row.pago.referencia or row.pago.id }}</code>
+                                            </td>
+                                            <td>
+                                                <span class="badge bg-secondary text-capitalize">{{ row.pago.metodo }}</span>
+                                            </td>
+                                            <td>
+                                                {% if row.pago.estado == 'completed' %}
+                                                    <span class="badge bg-success-subtle text-success border border-success-subtle">
+                                                        <i class="bi bi-check-circle-fill me-1"></i>{{ _('Completado') }}
+                                                    </span>
+                                                {% elif row.pago.estado == 'pending' %}
+                                                    <span class="badge bg-warning-subtle text-warning border border-warning-subtle">
+                                                        <i class="bi bi-hourglass-split me-1"></i>{{ _('Pendiente') }}
+                                                    </span>
+                                                {% else %}
+                                                    <span class="badge bg-danger-subtle text-danger border border-danger-subtle">
+                                                        <i class="bi bi-x-circle-fill me-1"></i>{{ _('Fallido') }}
+                                                    </span>
+                                                {% endif %}
+                                            </td>
+                                            <td class="text-end pe-4">
+                                                {% if row.pago.estado == 'completed' %}
+                                                    <a href="{{ url_for('user_profile.download_receipt', payment_id=row.pago.id) }}" class="btn btn-outline-primary btn-sm rounded-pill px-3">
+                                                        <i class="bi bi-file-earmark-pdf me-1"></i>
+                                                        {{ _('Bajar Recibo') }}
+                                                    </a>
+                                                {% elif row.pago.estado == 'pending' %}
+                                                    <a href="{{ url_for('paypal.resume_payment', payment_id=row.pago.id) }}" class="btn btn-primary btn-sm rounded-pill px-3">
+                                                        <i class="bi bi-credit-card me-1"></i>
+                                                        {{ _('Pagar') }}
+                                                    </a>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <div class="text-center py-5">
+                            <i class="bi bi-wallet2 text-muted" style="font-size: 3rem;"></i>
+                            <p class="text-muted mt-3 mb-0">{{ _('No tienes pagos registrados actualmente.') }}</p>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </main>
+    </body>
+</html>

--- a/now_lms/templates/payments/receipt_email.html
+++ b/now_lms/templates/payments/receipt_email.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="{{ current_locale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ _('Recibo de Pago') }}</title>
+</head>
+<body style="font-family: Arial, Helvetica, sans-serif; background-color: #f7fafc; margin: 0; padding: 20px; color: #2d3748;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); border: 1px solid #e2e8f0;">
+        <!-- Header -->
+        <tr>
+            <td style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; text-align: center;">
+                <h1 style="color: #ffffff; margin: 0; font-size: 24px; text-transform: uppercase; letter-spacing: 1px;">{{ _('Recibo de Pago') }}</h1>
+                <p style="color: #e2e8f0; margin: 5px 0 0 0; font-size: 14px;">{{ _('Transacción completada exitosamente') }}</p>
+            </td>
+        </tr>
+        <!-- Content -->
+        <tr>
+            <td style="padding: 30px;">
+                <p style="font-size: 16px; margin-top: 0;">{{ _('Hola') }} <strong>{{ pago.nombre }}</strong>,</p>
+                <p style="font-size: 14px; line-height: 1.6; color: #4a5568;">
+                    {{ _('Hemos recibido correctamente tu pago. A continuación encontrarás el resumen de tu transacción.') }}
+                </p>
+
+                <!-- Transaction Details Block -->
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color: #f7fafc; border-radius: 6px; padding: 20px; margin: 20px 0; border: 1px solid #edf2f7; font-size: 14px;">
+                    <tr>
+                        <td style="padding-bottom: 10px; color: #718096;"><strong>{{ _('ID Transacción') }}:</strong></td>
+                        <td style="padding-bottom: 10px; text-align: right; font-family: monospace;">{{ pago.referencia or pago.id }}</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-bottom: 10px; color: #718096;"><strong>{{ _('Fecha') }}:</strong></td>
+                        <td style="padding-bottom: 10px; text-align: right;">{{ pago.fecha.strftime('%Y-%m-%d %H:%M') if pago.fecha else '' }}</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-bottom: 10px; color: #718096;"><strong>{{ _('Método de Pago') }}:</strong></td>
+                        <td style="padding-bottom: 10px; text-align: right;">{{ pago.metodo | capitalize }}</td>
+                    </tr>
+                    <tr>
+                        <td style="color: #718096;"><strong>{{ _('Estado') }}:</strong></td>
+                        <td style="text-align: right; color: #38a169; font-weight: bold;">{{ _('Completado') }}</td>
+                    </tr>
+                </table>
+
+                <!-- Summary Table -->
+                <h3 style="font-size: 16px; color: #4a5568; margin: 25px 0 10px 0; border-bottom: 2px solid #edf2f7; padding-bottom: 8px;">{{ _('Resumen de Compra') }}</h3>
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="font-size: 14px;">
+                    <tr>
+                        <td style="padding: 10px 0;">
+                            <strong>{{ curso.nombre if curso else pago.curso }}</strong><br>
+                            <span style="font-size: 12px; color: #718096;">{{ _('Curso en Línea') }}</span>
+                        </td>
+                        <td style="text-align: right; padding: 10px 0; font-weight: bold; font-size: 16px;">
+                            {{ pago.monto }} {{ pago.moneda }}
+                        </td>
+                    </tr>
+                    <tr style="border-top: 1px solid #edf2f7;">
+                        <td style="padding: 15px 0 5px 0; text-align: right; font-weight: bold;">{{ _('Total Pagado') }}:</td>
+                        <td style="padding: 15px 0 5px 0; text-align: right; font-weight: bold; font-size: 18px; color: #667eea;">
+                            {{ pago.monto }} {{ pago.moneda }}
+                        </td>
+                    </tr>
+                </table>
+
+                <p style="font-size: 14px; line-height: 1.6; color: #4a5568; margin-top: 30px;">
+                    {{ _('Ya tienes acceso completo al curso. Haz clic en el siguiente enlace para comenzar tu aprendizaje:') }}
+                </p>
+
+                <!-- Call to Action -->
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin: 20px 0 30px 0; text-align: center;">
+                    <tr>
+                        <td>
+                            <a href="{{ url_for('course.tomar_curso', course_code=pago.curso, _external=True) }}" style="background-color: #667eea; color: #ffffff; padding: 12px 30px; text-decoration: none; border-radius: 25px; font-weight: bold; display: inline-block; box-shadow: 0 4px 6px rgba(102, 126, 234, 0.3);">
+                                {{ _('Comenzar Curso') }}
+                            </a>
+                        </td>
+                    </tr>
+                </table>
+
+                <p style="font-size: 12px; color: #a0aec0; text-align: center; margin-top: 30px; border-top: 1px solid #edf2f7; padding-top: 20px;">
+                    {{ _('Gracias por formar parte de nuestra comunidad.') }}<br>
+                    <strong>{{ config().titulo or 'NOW LMS' }}</strong>
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/now_lms/templates/payments/receipt_pdf.html
+++ b/now_lms/templates/payments/receipt_pdf.html
@@ -144,7 +144,7 @@
                 <td>
                     <strong>{{ curso.nombre if curso else pago.curso }}</strong>
                     <p style="margin: 5px 0 0 0; font-size: 12px; color: #718096;">
-                        {{ _('Curso en Línea') }} - Código: {{ pago.curso }}
+                        {{ _('Curso en Línea') }} - {{ _('Código') }}: {{ pago.curso }}
                     </p>
                 </td>
                 <td style="text-align: right; vertical-align: middle; font-size: 16px;">

--- a/now_lms/templates/payments/receipt_pdf.html
+++ b/now_lms/templates/payments/receipt_pdf.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="{{ current_locale() }}">
+<head>
+    <meta charset="utf-8">
+    <title>{{ _('Recibo de Pago') }}</title>
+    <style>
+        @page {
+            size: letter;
+            margin: 40px;
+        }
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+            color: #333333;
+            line-height: 1.5;
+            font-size: 14px;
+        }
+        .header {
+            border-bottom: 2px solid #667eea;
+            padding-bottom: 20px;
+            margin-bottom: 30px;
+        }
+        .header-title {
+            font-size: 28px;
+            color: #667eea;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin: 0;
+        }
+        .company-details {
+            text-align: right;
+            float: right;
+        }
+        .receipt-info {
+            margin-bottom: 30px;
+        }
+        .receipt-info-col {
+            width: 48%;
+            display: inline-block;
+            vertical-align: top;
+        }
+        .section-title {
+            font-size: 16px;
+            color: #764ba2;
+            border-bottom: 1px solid #764ba2;
+            padding-bottom: 5px;
+            margin-bottom: 10px;
+            font-weight: bold;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+            margin-bottom: 30px;
+        }
+        th {
+            background-color: #667eea;
+            color: white;
+            text-align: left;
+            padding: 10px;
+            font-weight: bold;
+        }
+        td {
+            padding: 10px;
+            border-bottom: 1px solid #e2e8f0;
+        }
+        .total-row {
+            font-weight: bold;
+            font-size: 16px;
+            background-color: #f7fafc;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 50px;
+            font-size: 12px;
+            color: #718096;
+            border-top: 1px solid #e2e8f0;
+            padding-top: 20px;
+        }
+        .badge {
+            background-color: #48bb78;
+            color: white;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <div class="receipt-info-col">
+            <h1 class="header-title">{{ _('Recibo de Pago') }}</h1>
+            <p style="margin: 5px 0 0 0; font-size: 16px; color: #718096;">
+                {{ _('Referencia') }}: {{ pago.referencia or pago.id }}
+            </p>
+        </div>
+        <div class="receipt-info-col" style="text-align: right;">
+            <p style="font-size: 20px; font-weight: bold; margin: 0; color: #4a5568;">
+                {{ config().titulo or 'NOW LMS' }}
+            </p>
+            <p style="margin: 5px 0 0 0; color: #718096;">
+                {{ _('Fecha') }}: {{ pago.fecha.strftime('%Y-%m-%d %H:%M') if pago.fecha else '' }}
+            </p>
+        </div>
+        <div style="clear: both;"></div>
+    </div>
+
+    <div class="receipt-info">
+        <div class="receipt-info-col">
+            <div class="section-title">{{ _('Facturado a') }}</div>
+            <p style="margin: 0 0 5px 0;"><strong>{{ pago.nombre }} {{ pago.apellido }}</strong></p>
+            <p style="margin: 0 0 5px 0;">{{ pago.correo_electronico }}</p>
+            {% if pago.direccion1 %}
+                <p style="margin: 0 0 5px 0;">{{ pago.direccion1 }}</p>
+            {% endif %}
+            {% if pago.direccion2 %}
+                <p style="margin: 0 0 5px 0;">{{ pago.direccion2 }}</p>
+            {% endif %}
+            <p style="margin: 0;">
+                {% if pago.provincia %}{{ pago.provincia }}, {% endif %}
+                {% if pago.pais %}{{ pago.pais }} {% endif %}
+                {% if pago.codigo_postal %}({{ pago.codigo_postal }}){% endif %}
+            </p>
+        </div>
+        <div class="receipt-info-col" style="float: right;">
+            <div class="section-title">{{ _('Detalles del Pago') }}</div>
+            <p style="margin: 0 0 5px 0;"><strong>{{ _('Método') }}:</strong> {{ pago.metodo | capitalize }}</p>
+            <p style="margin: 0 0 5px 0;"><strong>{{ _('Estado') }}:</strong> <span class="badge">{{ _('Completado') }}</span></p>
+            <p style="margin: 0;"><strong>{{ _('ID Transacción') }}:</strong> {{ pago.referencia or pago.id }}</p>
+        </div>
+        <div style="clear: both;"></div>
+    </div>
+
+    <div class="section-title">{{ _('Resumen de la Transacción') }}</div>
+    <table>
+        <thead>
+            <tr>
+                <th>{{ _('Descripción') }}</th>
+                <th style="text-align: right; width: 150px;">{{ _('Total') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <strong>{{ curso.nombre if curso else pago.curso }}</strong>
+                    <p style="margin: 5px 0 0 0; font-size: 12px; color: #718096;">
+                        {{ _('Curso en Línea') }} - Código: {{ pago.curso }}
+                    </p>
+                </td>
+                <td style="text-align: right; vertical-align: middle; font-size: 16px;">
+                    {{ pago.monto }} {{ pago.moneda }}
+                </td>
+            </tr>
+            <tr class="total-row">
+                <td style="text-align: right;">{{ _('Total Pagado') }}:</td>
+                <td style="text-align: right; color: #667eea; font-size: 18px;">
+                    {{ pago.monto }} {{ pago.moneda }}
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="footer">
+        <p>{{ _('Gracias por su confianza y preferencia en nuestra plataforma.') }}</p>
+        <p style="margin-top: 10px; font-size: 10px;">
+            {{ _('Este es un recibo generado automáticamente y sirve como comprobante de pago.') }}
+        </p>
+    </div>
+</body>
+</html>

--- a/now_lms/templates/perfiles/estudiante.html
+++ b/now_lms/templates/perfiles/estudiante.html
@@ -119,6 +119,21 @@
                                         </div>
                                     </div>
                                 </div>
+
+                                <div class="row">
+                                    <div class="col-md-12 mb-3">
+                                        <div class="card border-secondary">
+                                            <div class="card-body text-center">
+                                                <i class="fas fa-credit-card fa-2x text-secondary mb-2"></i>
+                                                <h5>{{ _('Historial de Pagos') }}</h5>
+                                                <p class="text-muted">{{ _('Consulta tus transacciones y descarga tus recibos') }}</p>
+                                                <a href="{{ url_for('user_profile.payments_history') }}" class="btn btn-secondary"
+                                                    >{{ _('Ver Pagos') }}</a
+                                                >
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -143,6 +158,9 @@
                                     </a>
                                     <a href="{{ url_for('calendar.calendar_view') }}" class="btn btn-outline-success btn-sm">
                                         <i class="fas fa-calendar"></i> {{ _('Mi Calendario') }}
+                                    </a>
+                                    <a href="{{ url_for('user_profile.payments_history') }}" class="btn btn-outline-warning btn-sm">
+                                        <i class="bi bi-wallet2 me-2"></i> {{ _('Historial de Pagos') }}
                                     </a>
                                     <a href="{{ url_for('calendar.export_ics') }}" class="btn btn-outline-info btn-sm">
                                         <i class="fas fa-download"></i> {{ _('Exportar Calendario') }}

--- a/now_lms/vistas/paypal.py
+++ b/now_lms/vistas/paypal.py
@@ -352,6 +352,14 @@ def enviar_recibo_pago(pago: Pago) -> None:
     from now_lms.db import Curso
     from now_lms.i18n import _
 
+    recipient = pago.correo_electronico
+    if not recipient:
+        logging.warning(
+            "Payment %s has no email address; receipt not sent.",
+            pago.referencia or pago.id,
+        )
+        return
+
     try:
         mail_config = _config()
         if not mail_config.mail_configured:
@@ -366,7 +374,7 @@ def enviar_recibo_pago(pago: Pago) -> None:
 
         msg = Message(
             subject=_("Recibo de Pago - %(curso_nombre)s") % {"curso_nombre": curso.nombre if curso else pago.curso},
-            recipients=[pago.correo_electronico or current_user.correo_electronico],
+            recipients=[recipient],
             sender=((mail_config.MAIL_DEFAULT_SENDER_NAME or "NOW LMS"), mail_config.MAIL_DEFAULT_SENDER),
         )
         msg.html = html_body
@@ -376,8 +384,11 @@ def enviar_recibo_pago(pago: Pago) -> None:
             background=True,
             _log=f"Recibo de pago {pago.referencia} enviado por correo electrónico a {msg.recipients}."
         )
-    except Exception as exc:
-        logging.exception(f"Error al enviar el recibo de pago por correo electrónico: {exc}")
+    except Exception:
+        logging.exception(
+            "Failed to send receipt for payment %s",
+            pago.referencia or pago.id,
+        )
 
 
 def _process_confirmed_payment(payment_data: dict[str, object]) -> tuple[FlaskResponse, int]:

--- a/now_lms/vistas/paypal.py
+++ b/now_lms/vistas/paypal.py
@@ -344,6 +344,42 @@ def _update_coupon_usage(pago: Any, course_code: str, order_id: str) -> None:
         logging.warning(f"Failed to update coupon usage for payment {order_id}: {exc}")
 
 
+def enviar_recibo_pago(pago: Pago) -> None:
+    """Envía un recibo de pago por correo electrónico en HTML si el correo está configurado."""
+    from now_lms.mail import send_mail, _config
+    from flask_mail import Message
+    from flask import render_template
+    from now_lms.db import Curso
+    from now_lms.i18n import _
+
+    try:
+        mail_config = _config()
+        if not mail_config.mail_configured:
+            logging.info("El correo electrónico no está configurado. No se enviará recibo por correo.")
+            return
+
+        curso = database.session.execute(
+            database.select(Curso).filter_by(codigo=pago.curso)
+        ).scalars().first()
+
+        html_body = render_template("payments/receipt_email.html", pago=pago, curso=curso)
+
+        msg = Message(
+            subject=_("Recibo de Pago - %(curso_nombre)s") % {"curso_nombre": curso.nombre if curso else pago.curso},
+            recipients=[pago.correo_electronico or current_user.correo_electronico],
+            sender=((mail_config.MAIL_DEFAULT_SENDER_NAME or "NOW LMS"), mail_config.MAIL_DEFAULT_SENDER),
+        )
+        msg.html = html_body
+
+        send_mail(
+            msg,
+            background=True,
+            _log=f"Recibo de pago {pago.referencia} enviado por correo electrónico a {msg.recipients}."
+        )
+    except Exception as exc:
+        logging.exception(f"Error al enviar el recibo de pago por correo electrónico: {exc}")
+
+
 def _process_confirmed_payment(payment_data: dict[str, object]) -> tuple[FlaskResponse, int]:
     """Complete the local payment and enrollment transaction."""
     order_id = cast(str, payment_data["order_id"])
@@ -363,6 +399,10 @@ def _process_confirmed_payment(payment_data: dict[str, object]) -> tuple[FlaskRe
 
     _crear_indice_avance_curso(course_code)
     logging.info(f"Payment {order_id} successfully processed for user {current_user.usuario}, course {course_code}")
+
+    # Enviar recibo de pago
+    enviar_recibo_pago(pago)
+
     return jsonify({
         "success": True,
         "message": "Pago completado exitosamente",

--- a/now_lms/vistas/profiles/user.py
+++ b/now_lms/vistas/profiles/user.py
@@ -233,3 +233,51 @@ def cambiar_contrasena(ulid: str) -> str | Response:
             flash("Error al actualizar la contraseña.", "error")
 
     return render_template(TEMPLATE_CAMBIAR_CONTRASENA, form=form, usuario=usuario_)
+
+
+@user_profile.route("/payments", methods=["GET"])
+@login_required
+def payments_history() -> str:
+    """Historial de pagos del estudiante."""
+    from now_lms.db import Pago, Curso
+
+    pagos = database.session.execute(
+        database.select(Pago)
+        .filter_by(usuario=current_user.usuario)
+        .order_by(Pago.fecha.desc())
+    ).scalars().all()
+
+    pago_rows = []
+    for pago in pagos:
+        curso = database.session.execute(
+            database.select(Curso).filter_by(codigo=pago.curso)
+        ).scalar_one_or_none()
+        pago_rows.append({"pago": pago, "curso": curso})
+
+    return render_template("payments/history.html", pago_rows=pago_rows)
+
+
+@user_profile.route("/payments/receipt/<payment_id>", methods=["GET"])
+@login_required
+def download_receipt(payment_id: str) -> Response:
+    """Descargar recibo de pago sencillo en PDF."""
+    from now_lms.db import Pago, Curso
+    from flask_weasyprint import HTML, render_pdf
+
+    pago = database.session.execute(
+        database.select(Pago).filter_by(id=payment_id, usuario=current_user.usuario, estado="completed")
+    ).scalar_one_or_none()
+
+    if not pago:
+        abort(404)
+
+    curso = database.session.execute(
+        database.select(Curso).filter_by(codigo=pago.curso)
+    ).scalar_one_or_none()
+
+    html_content = render_template("payments/receipt_pdf.html", pago=pago, curso=curso)
+
+    return render_pdf(
+        HTML(string=html_content),
+        download_filename=f"receipt_{pago.referencia or pago.id}.pdf"
+    )

--- a/now_lms/vistas/profiles/user.py
+++ b/now_lms/vistas/profiles/user.py
@@ -238,20 +238,18 @@ def cambiar_contrasena(ulid: str) -> str | Response:
 @user_profile.route("/payments", methods=["GET"])
 @login_required
 def payments_history() -> str:
-    """Historial de pagos del estudiante."""
+    """Historial de pagos para cualquier usuario autenticado."""
     from now_lms.db import Pago, Curso
 
-    pagos = database.session.execute(
-        database.select(Pago)
-        .filter_by(usuario=current_user.usuario)
+    results = database.session.execute(
+        database.select(Pago, Curso)
+        .outerjoin(Curso, Pago.curso == Curso.codigo)
+        .filter(Pago.usuario == current_user.usuario)
         .order_by(Pago.fecha.desc())
-    ).scalars().all()
+    ).all()
 
     pago_rows = []
-    for pago in pagos:
-        curso = database.session.execute(
-            database.select(Curso).filter_by(codigo=pago.curso)
-        ).scalar_one_or_none()
+    for pago, curso in results:
         pago_rows.append({"pago": pago, "curso": curso})
 
     return render_template("payments/history.html", pago_rows=pago_rows)

--- a/tests/test_payments_receipts.py
+++ b/tests/test_payments_receipts.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+from now_lms.auth import proteger_passwd
+from now_lms.db import Curso, Pago, Usuario, database
+
+
+def _crear_estudiante(db_session, username="student_receipts", email="student@example.com") -> Usuario:
+    user = Usuario(
+        usuario=username,
+        acceso=proteger_passwd("password"),
+        nombre="Student",
+        apellido="Receipts",
+        correo_electronico=email,
+        tipo="student",
+        activo=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _crear_curso(db_session, code="PAY003", name="Receipt Course") -> Curso:
+    curso = Curso(
+        codigo=code,
+        nombre=name,
+        descripcion_corta="Course with receipt",
+        descripcion="Course with receipt for testing",
+        estado="open",
+        pagado=True,
+        precio=50.00,
+    )
+    db_session.add(curso)
+    db_session.commit()
+    return curso
+
+
+def test_student_payments_history_renders(app, client, db_session):
+    student = _crear_estudiante(db_session)
+    curso = _crear_curso(db_session)
+
+    pago = Pago(
+        usuario=student.usuario,
+        curso=curso.codigo,
+        nombre=student.nombre,
+        apellido=student.apellido,
+        correo_electronico=student.correo_electronico,
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-REC-123",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    # Log in as student
+    client.post("/user/login", data={"usuario": student.usuario, "acceso": "password"}, follow_redirects=False)
+
+    # Get payments history page
+    resp = client.get("/payments")
+    assert resp.status_code == 200
+    assert b"Mis Pagos Registrados" in resp.data or b"My Registered Payments" in resp.data
+    assert b"ORDER-REC-123" in resp.data
+    assert b"Receipt Course" in resp.data
+
+
+def test_download_receipt_pdf(app, client, db_session):
+    student = _crear_estudiante(db_session, "student_pdf", "pdf@example.com")
+    curso = _crear_curso(db_session, "PAY_PDF", "PDF Course")
+
+    pago = Pago(
+        usuario=student.usuario,
+        curso=curso.codigo,
+        nombre=student.nombre,
+        apellido=student.apellido,
+        correo_electronico=student.correo_electronico,
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-PDF-999",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    # Log in as student
+    client.post("/user/login", data={"usuario": student.usuario, "acceso": "password"}, follow_redirects=False)
+
+    # Download PDF receipt
+    resp = client.get(f"/payments/receipt/{pago.id}")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/pdf"
+    assert b"%PDF" in resp.data
+
+
+def test_download_receipt_pdf_unauthorized_or_not_found(app, client, db_session):
+    student1 = _crear_estudiante(db_session, "student_owner", "owner@example.com")
+    student2 = _crear_estudiante(db_session, "student_other", "other@example.com")
+    curso = _crear_curso(db_session, "PAY_UNAUTH", "Unauth Course")
+
+    pago = Pago(
+        usuario=student1.usuario,
+        curso=curso.codigo,
+        nombre=student1.nombre,
+        apellido=student1.apellido,
+        correo_electronico=student1.correo_electronico,
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-OWNER",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    # Log in as other student (not the owner)
+    client.post("/user/login", data={"usuario": student2.usuario, "acceso": "password"}, follow_redirects=False)
+
+    # Attempt to download other student's receipt
+    resp = client.get(f"/payments/receipt/{pago.id}")
+    assert resp.status_code == 404
+
+
+@patch("now_lms.mail.send_mail")
+@patch("now_lms.mail._config")
+def test_email_receipt_sending(mock_config, mock_send_mail, app, db_session):
+    # Set up mock configuration to simulate SMTP enabled
+    mock_config.return_value = MagicMock(
+        mail_configured=True,
+        MAIL_DEFAULT_SENDER_NAME="NOW LMS",
+        MAIL_DEFAULT_SENDER="no-reply@nowlms.com"
+    )
+
+    from now_lms.vistas.paypal import enviar_recibo_pago
+
+    student = _crear_estudiante(db_session, "student_email", "email_test@example.com")
+    curso = _crear_curso(db_session, "PAY_EMAIL", "Email Course")
+
+    pago = Pago(
+        usuario=student.usuario,
+        curso=curso.codigo,
+        nombre=student.nombre,
+        apellido=student.apellido,
+        correo_electronico=student.correo_electronico,
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-EMAIL-888",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    with app.test_request_context():
+        # Call the email helper
+        enviar_recibo_pago(pago)
+
+        # Verify send_mail was called
+        assert mock_send_mail.called
+        sent_msg = mock_send_mail.call_args[0][0]
+        assert "Recibo de Pago" in sent_msg.subject or "Receipt" in sent_msg.subject
+        assert "email_test@example.com" in sent_msg.recipients
+        assert "ORDER-EMAIL-888" in sent_msg.html
+        assert "Email Course" in sent_msg.html

--- a/tests/test_payments_receipts.py
+++ b/tests/test_payments_receipts.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
 
-import pytest
 from unittest.mock import patch, MagicMock
 from datetime import datetime
 from now_lms.auth import proteger_passwd
-from now_lms.db import Curso, Pago, Usuario, database
+from now_lms.db import Curso, Pago, Usuario
 
 
 def _crear_estudiante(db_session, username="student_receipts", email="student@example.com") -> Usuario:
@@ -170,3 +169,120 @@ def test_email_receipt_sending(mock_config, mock_send_mail, app, db_session):
         assert "email_test@example.com" in sent_msg.recipients
         assert "ORDER-EMAIL-888" in sent_msg.html
         assert "Email Course" in sent_msg.html
+
+
+@patch("now_lms.mail.send_mail")
+@patch("now_lms.mail._config")
+def test_email_receipt_not_sent_when_smtp_disabled(mock_config, mock_send_mail, app, db_session):
+    # Set up mock configuration to simulate SMTP disabled
+    mock_config.return_value = MagicMock(
+        mail_configured=False
+    )
+
+    from now_lms.vistas.paypal import enviar_recibo_pago
+
+    student = _crear_estudiante(db_session, "student_smtp_off", "smtp_off@example.com")
+    curso = _crear_curso(db_session, "PAY_SMTPOFF", "SMTP Off Course")
+
+    pago = Pago(
+        usuario=student.usuario,
+        curso=curso.codigo,
+        nombre=student.nombre,
+        apellido=student.apellido,
+        correo_electronico=student.correo_electronico,
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-SMTPOFF",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    with app.test_request_context():
+        enviar_recibo_pago(pago)
+
+        # Verify send_mail was NOT called
+        mock_send_mail.assert_not_called()
+
+
+@patch("now_lms.mail.send_mail")
+def test_email_receipt_not_sent_when_no_payment_email(mock_send_mail, app, db_session):
+    from now_lms.vistas.paypal import enviar_recibo_pago
+
+    student = _crear_estudiante(db_session, "student_no_email", "no_email@example.com")
+    curso = _crear_curso(db_session, "PAY_NOEMAIL", "No Email Course")
+
+    pago = Pago(
+        usuario=student.usuario,
+        curso=curso.codigo,
+        nombre=student.nombre,
+        apellido=student.apellido,
+        correo_electronico="",  # empty string is falsy but passes DB NOT NULL constraint
+        monto=50.00,
+        moneda="USD",
+        metodo="paypal",
+        estado="completed",
+        referencia="ORDER-NOEMAIL",
+        fecha=datetime.now(),
+    )
+    db_session.add(pago)
+    db_session.commit()
+
+    with app.test_request_context():
+        enviar_recibo_pago(pago)
+
+        # Verify send_mail was NOT called
+        mock_send_mail.assert_not_called()
+
+
+@patch("now_lms.mail.send_mail")
+@patch("now_lms.mail._config")
+@patch("now_lms.vistas.paypal.get_paypal_access_token")
+@patch("now_lms.vistas.paypal.verify_paypal_payment")
+def test_payment_idempotency_ignores_already_completed(mock_verify, mock_token, mock_config, mock_send_mail, app, client, db_session):
+    # Set up mock configuration to simulate SMTP enabled
+    mock_config.return_value = MagicMock(
+        mail_configured=True,
+        MAIL_DEFAULT_SENDER_NAME="NOW LMS",
+        MAIL_DEFAULT_SENDER="no-reply@nowlms.com"
+    )
+
+    # Tests that processing a second payment confirmation for the same orderID behaves idempotently and does NOT send receipt email twice.
+    student = _crear_estudiante(db_session, "student_idemp", "idemp@example.com")
+    curso = _crear_curso(db_session, "PAY_IDEMP", "Idempotency Course")
+
+    # Configure mock responses for paypal API
+    mock_token.return_value = "fake-access-token"
+    mock_verify.return_value = {
+        "verified": True,
+        "status": "COMPLETED",
+        "amount": "50.00",
+        "currency": "USD",
+        "payer_id": "PAYER123"
+    }
+
+    # Log in as student
+    client.post("/user/login", data={"usuario": student.usuario, "acceso": "password"}, follow_redirects=False)
+
+    payload = {
+        "orderID": "ORDER-IDEMP-111",
+        "payerID": "PAYER123",
+        "courseCode": "PAY_IDEMP",
+        "amount": "50.00"
+    }
+
+    # First payment request
+    resp1 = client.post("/paypal_checkout/confirm_payment", json=payload)
+    assert resp1.status_code == 200
+
+    # Capture how many times send_mail was called (should be 1)
+    assert mock_send_mail.call_count == 1
+
+    # Second payment request with same details (simulating client retry or duplicate callback)
+    resp2 = client.post("/paypal_checkout/confirm_payment", json=payload)
+    assert resp2.status_code == 200
+
+    # Email count should still be 1 (idempotent, didn't resend)
+    assert mock_send_mail.call_count == 1


### PR DESCRIPTION
This submission implements a complete payment receipt system for students who make PayPal payments. When a payment is successfully received/completed, the system automatically triggers a background HTML receipt email to the student (if SMTP is configured). Additionally, a new '/payments' dashboard provides students with a detailed summary of their transactions and a direct option to download a beautiful, simple, and fully translated PDF receipt generated via Weasyprint. All user-facing receipt texts respect the active system locale, and comprehensive security checks prevent unauthorized users from downloading other students' receipts. Outstanding unit and integration tests are added to verify all new features without regressions.

---
*PR created automatically by Jules for task [12187185202117694957](https://jules.google.com/task/12187185202117694957) started by @williamjmorenor*