### PR TITLE
Fix Configuration Migration (Rename r to csrf_seed) and Theme Column Length

### DIFF
--- a/now_lms/db/__init__.py
+++ b/now_lms/db/__init__.py
@@ -685,7 +685,7 @@ class Configuracion(database.Model, BaseTabla):
 class Style(database.Model, BaseTabla):
     """Configuration for site appearance and theming."""
 
-    theme = database.Column(database.String(15))
+    theme = database.Column(database.String(40))
     custom_logo = database.Column(database.Boolean())
     custom_logo_ext = database.Column(database.String(5))
     custom_favicon = database.Column(database.Boolean())  # png

--- a/now_lms/migrations/20260725_120000_rename_r_and_increase_theme_length.py
+++ b/now_lms/migrations/20260725_120000_rename_r_and_increase_theme_length.py
@@ -1,0 +1,93 @@
+"""Rename r to csrf_seed and increase theme column length to 40
+
+Revision ID: 20260725_120000
+Revises: 20260724_180000
+Create Date: 2026-07-25 12:00:00
+
+This migration:
+1. Renames the 'r' column on 'configuracion' table to 'csrf_seed'.
+   If 'r' does not exist but 'csrf_seed' is also missing, 'csrf_seed' is created.
+2. Increases the 'theme' column on 'style' table to 40 characters instead of 15 or 10.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20260725_120000"
+down_revision = "20260724_180000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # 1. Handle configuracion table (rename r to csrf_seed or add csrf_seed)
+    if "configuracion" in inspector.get_table_names():
+        columns = {col["name"]: col for col in inspector.get_columns("configuracion")}
+
+        if "r" in columns:
+            # Rename r to csrf_seed
+            with op.batch_alter_table("configuracion") as batch_op:
+                batch_op.alter_column(
+                    "r",
+                    new_column_name="csrf_seed",
+                    existing_type=sa.LargeBinary(),
+                    existing_nullable=True
+                )
+        elif "csrf_seed" not in columns:
+            # Add csrf_seed as a new column
+            with op.batch_alter_table("configuracion") as batch_op:
+                batch_op.add_column(sa.Column("csrf_seed", sa.LargeBinary(), nullable=True))
+
+    # 2. Handle style table (increase theme column length to 40)
+    if "style" in inspector.get_table_names():
+        columns = {col["name"]: col for col in inspector.get_columns("style")}
+        if "theme" in columns:
+            current_type = columns["theme"]["type"]
+            current_length = getattr(current_type, "length", None)
+
+            # If current length is not already 40, alter the column
+            if current_length != 40:
+                with op.batch_alter_table("style") as batch_op:
+                    batch_op.alter_column(
+                        "theme",
+                        existing_type=sa.String(current_length or 15),
+                        type_=sa.String(40),
+                        existing_nullable=True
+                    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # 1. Handle configuracion table (rename csrf_seed back to r)
+    if "configuracion" in inspector.get_table_names():
+        columns = {col["name"]: col for col in inspector.get_columns("configuracion")}
+        if "csrf_seed" in columns:
+            with op.batch_alter_table("configuracion") as batch_op:
+                batch_op.alter_column(
+                    "csrf_seed",
+                    new_column_name="r",
+                    existing_type=sa.LargeBinary(),
+                    existing_nullable=True
+                )
+
+    # 2. Handle style table (restore theme column length back to 15)
+    if "style" in inspector.get_table_names():
+        columns = {col["name"]: col for col in inspector.get_columns("style")}
+        if "theme" in columns:
+            current_type = columns["theme"]["type"]
+            current_length = getattr(current_type, "length", None)
+
+            if current_length != 15:
+                with op.batch_alter_table("style") as batch_op:
+                    batch_op.alter_column(
+                        "theme",
+                        existing_type=sa.String(current_length or 40),
+                        type_=sa.String(15),
+                        existing_nullable=True
+                    )

--- a/tests/test_alembic_upgrade.py
+++ b/tests/test_alembic_upgrade.py
@@ -77,6 +77,43 @@ def test_alembic_upgrade_app_context(monkeypatch):
             # La tabla alembic_version no existe después del downgrade, lo cual es válido
             pass
 
+        # Verificar que en el estado downgrade('base'), las columnas críticas se revirtieron correctamente
+        import sqlalchemy as sa
+        test_secret = b"my-ultra-secret-key-1234"
+        try:
+            inspector_downgraded = sa.inspect(db.engine)
+            existing_tables_dg = inspector_downgraded.get_table_names()
+
+            if "configuracion" in existing_tables_dg:
+                config_columns_dg = {col["name"]: col for col in inspector_downgraded.get_columns("configuracion")}
+                assert "r" in config_columns_dg, "En downgrade('base'), la columna 'r' debe existir en configuracion"
+                assert "csrf_seed" not in config_columns_dg, "En downgrade('base'), la columna 'csrf_seed' no debe existir"
+
+                # Poblar la columna 'r' con datos binarios para probar conservación de datos
+                config_count = db.session.execute(db.text("SELECT COUNT(*) FROM configuracion")).scalar()
+                if config_count == 0:
+                    db.session.execute(
+                        db.text("INSERT INTO configuracion (id, titulo, descripcion, r) VALUES (:id, :titulo, :desc, :r)"),
+                        {"id": "test-config-id", "titulo": "Test", "desc": "Desc", "r": test_secret}
+                    )
+                else:
+                    first_id = db.session.execute(db.text("SELECT id FROM configuracion LIMIT 1")).scalar()
+                    db.session.execute(
+                        db.text("UPDATE configuracion SET r = :r WHERE id = :id"),
+                        {"r": test_secret, "id": first_id}
+                    )
+                db.session.commit()
+
+            if "style" in existing_tables_dg:
+                style_columns_dg = {col["name"]: col for col in inspector_downgraded.get_columns("style")}
+                assert "theme" in style_columns_dg, "En downgrade('base'), la columna 'theme' debe existir en style"
+                theme_type_dg = style_columns_dg["theme"]["type"]
+                assert getattr(theme_type_dg, "length", None) == 15, (
+                    f"En downgrade('base'), la columna 'theme' debe tener longitud 15, obtenido: {getattr(theme_type_dg, 'length', None)}"
+                )
+        except (OperationalError, ProgrammingError):
+            pass
+
         # Paso 5: Hacer upgrade de nuevo hasta head
         alembic.upgrade()
         db.session.commit()
@@ -84,6 +121,29 @@ def test_alembic_upgrade_app_context(monkeypatch):
         # Verificar que ahora sí hay una versión válida
         version_after_final_upgrade = db.session.execute(db.text("SELECT version_num FROM alembic_version")).scalar()
         assert version_after_final_upgrade is not None, "Después de upgrade(), debe haber una versión válida"
+
+        # Asegurar que migraciones críticas están aplicadas al finalizar el upgrade a head
+        inspector_upgraded = sa.inspect(db.engine)
+        existing_tables_ug = inspector_upgraded.get_table_names()
+
+        assert "configuracion" in existing_tables_ug, "La tabla configuracion debe existir"
+        config_columns_ug = {col["name"]: col for col in inspector_upgraded.get_columns("configuracion")}
+        assert "csrf_seed" in config_columns_ug, "La columna csrf_seed debe existir en configuracion"
+        assert "r" not in config_columns_ug, "La columna r no debe existir en configuracion (debe haber sido renombrada)"
+
+        # Verificar conservación de datos
+        preserved_secret = db.session.execute(db.text("SELECT csrf_seed FROM configuracion LIMIT 1")).scalar()
+        assert preserved_secret == test_secret, (
+            f"La clave cifrada debe conservarse idéntica después del upgrade. Esperado: {test_secret}, Obtenido: {preserved_secret}"
+        )
+
+        assert "style" in existing_tables_ug, "La tabla style debe existir"
+        style_columns_ug = {col["name"]: col for col in inspector_upgraded.get_columns("style")}
+        assert "theme" in style_columns_ug, "La columna theme debe existir en style"
+        theme_type_ug = style_columns_ug["theme"]["type"]
+        assert getattr(theme_type_ug, "length", None) == 40, (
+            f"La columna theme en style debe tener longitud 40, actual: {getattr(theme_type_ug, 'length', None)}"
+        )
 
         # Verificar que el ciclo completo funcionó correctamente
         # La versión final debe ser igual a la inicial si no se agregaron migraciones durante el test


### PR DESCRIPTION
This PR adds an Alembic migration that renames column `r` in the `configuracion` table to `csrf_seed` while preserving existing values to prevent briqueado/data recovery issues, and increases the `theme` column length in the `style` table to 40 characters (from 15/10). It also enhances the test suite to verify data preservation of `r` values and theme length attributes during downgrade/upgrade roundtrips across SQLite, MySQL, and PostgreSQL.

---
*PR created automatically by Jules for task [719976189217718333](https://jules.google.com/task/719976189217718333) started by @williamjmorenor*