### PR TITLE
feat(wsgi): let Waitress trust a reverse proxy via NOW_LMS_TRUSTED_PROXY

### DIFF
--- a/run.py
+++ b/run.py
@@ -17,6 +17,13 @@ from now_lms.worker_config import get_worker_config_from_env
 
 PORT = environ.get("PORT") or 8080
 
+# When running behind a trusted reverse proxy that terminates TLS (e.g. Caddy/Nginx),
+# set NOW_LMS_TRUSTED_PROXY to the proxy's address ("*" to trust any, safe when the app
+# is bound to loopback and only the proxy can reach it). Without this, Waitress strips the
+# X-Forwarded-* headers (clear_untrusted_proxy_headers defaults True), so NOW_LMS_FORCE_HTTPS
+# never sees X-Forwarded-Proto=https and redirect-loops. Default None keeps current behavior.
+TRUSTED_PROXY = environ.get("NOW_LMS_TRUSTED_PROXY") or None
+
 # Get WSGI server from environment variable (defaults to waitress)
 WSGI_SERVER = environ.get("WSGI_SERVER", "waitress").lower()
 
@@ -99,8 +106,7 @@ if init_app():
             from waitress import serve
 
             log.info(f"Starting Waitress WSGI server on port {PORT} with {threads} threads")
-            serve(
-                lms_app,
+            waitress_kwargs = dict(
                 host="0.0.0.0",
                 port=PORT,
                 threads=threads,
@@ -108,6 +114,15 @@ if init_app():
                 cleanup_interval=30,
                 _quiet=False,
             )
+            if TRUSTED_PROXY:
+                # Trust the reverse proxy so X-Forwarded-* headers survive to the app.
+                waitress_kwargs.update(
+                    trusted_proxy=TRUSTED_PROXY,
+                    trusted_proxy_headers={"x-forwarded-for", "x-forwarded-proto", "x-forwarded-host"},
+                    clear_untrusted_proxy_headers=True,
+                )
+                log.info(f"Waitress trusting reverse proxy: {TRUSTED_PROXY}")
+            serve(lms_app, **waitress_kwargs)
         except ImportError:
             log.error("Waitress no está instalado. Por favor instálalo con: pip install waitress")
             log.error("No se pudo iniciar NOW Learning Management System.")

--- a/tests/test_run_trusted_proxy.py
+++ b/tests/test_run_trusted_proxy.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+"""
+Regression test for NOW_LMS_TRUSTED_PROXY wiring into Waitress in run.py.
+
+Behind a TLS-terminating reverse proxy, Waitress (clear_untrusted_proxy_headers
+defaults to True) strips X-Forwarded-* headers unless the proxy is explicitly
+trusted, so any FORCE_HTTPS-style check never sees X-Forwarded-Proto=https and
+the app redirect-loops. run.py's fix reads NOW_LMS_TRUSTED_PROXY and, when
+set, adds trusted_proxy / trusted_proxy_headers / clear_untrusted_proxy_headers
+to the kwargs passed to waitress.serve(); when unset, behavior is unchanged.
+
+run.py is a script, not an importable library module — it runs its startup
+sequence (DB migration, then waitress.serve()) at import time. To observe the
+kwargs actually handed to waitress.serve() without starting a real server or
+touching a real database, each case runs in a subprocess that:
+  1. monkeypatches now_lms.init_app and now_lms.alembic.upgrade to no-ops,
+     so run.py's pre-init "with lms_app.app_context(): alembic.upgrade()"
+     and "if init_app():" steps succeed without a real database (irrelevant
+     to what this test covers — that path is exercised separately by the
+     PostgreSQL/SQLite bootstrap regression tests);
+  2. monkeypatches waitress.serve() to capture its kwargs and exit instead of
+     actually serving;
+  3. imports run, which runs the above and then calls the patched serve().
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+_HARNESS = """
+import json
+import waitress
+import now_lms
+
+now_lms.init_app = lambda *a, **kw: True
+now_lms.alembic.upgrade = lambda *a, **kw: None
+
+captured = {}
+
+
+def fake_serve(app, **kwargs):
+    captured.update(kwargs)
+    print("CAPTURED_KWARGS=" + json.dumps(
+        {k: (sorted(v) if isinstance(v, set) else v) for k, v in kwargs.items()}
+    ))
+    raise SystemExit(0)
+
+
+waitress.serve = fake_serve
+
+import run  # noqa: F401  (module-level side effects are the point)
+"""
+
+
+def _captured_waitress_kwargs(trusted_proxy_value: str | None) -> dict:
+    env = os.environ.copy()
+    env.update(
+        {
+            "CI": "True",
+            "SECRET_KEY": "test-secret-key",
+            "DATABASE_URL": "sqlite:///:memory:",
+            "LOG_LEVEL": "ERROR",
+            "WSGI_SERVER": "waitress",
+        }
+    )
+    if trusted_proxy_value is None:
+        env.pop("NOW_LMS_TRUSTED_PROXY", None)
+    else:
+        env["NOW_LMS_TRUSTED_PROXY"] = trusted_proxy_value
+
+    result = subprocess.run(
+        [sys.executable, "-c", _HARNESS],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+    for line in result.stdout.splitlines():
+        if line.startswith("CAPTURED_KWARGS="):
+            return json.loads(line[len("CAPTURED_KWARGS=") :])
+    raise AssertionError(f"waitress.serve() kwargs were never captured.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+
+def test_waitress_trusts_the_proxy_when_env_opt_in_is_set():
+    kwargs = _captured_waitress_kwargs("*")
+
+    assert kwargs["trusted_proxy"] == "*"
+    assert sorted(kwargs["trusted_proxy_headers"]) == [
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+    ]
+    assert kwargs["clear_untrusted_proxy_headers"] is True
+
+
+def test_waitress_does_not_trust_any_proxy_when_env_opt_in_is_unset():
+    kwargs = _captured_waitress_kwargs(None)
+
+    assert "trusted_proxy" not in kwargs
+    assert "trusted_proxy_headers" not in kwargs
+    assert "clear_untrusted_proxy_headers" not in kwargs


### PR DESCRIPTION
## Problem

There is currently no way to tell Waitress to trust a reverse proxy, which makes `FORCE_HTTPS` unusable behind one.

Waitress defaults to `clear_untrusted_proxy_headers=True` and `trusted_proxy=None`, so it strips `X-Forwarded-*` from every request. When NOW LMS runs behind a TLS-terminating proxy (Caddy, Nginx, a load balancer), the app therefore never sees `X-Forwarded-Proto: https`. It concludes the request arrived over plain HTTP and issues an HTTPS redirect — to a URL the proxy sends straight back. The result is a redirect loop, and the site is unreachable.

`ProxyFix` alone cannot fix this: by the time the WSGI middleware runs, Waitress has already removed the headers. The trust has to be configured on the server.

## Fix

A single opt-in environment variable, `NOW_LMS_TRUSTED_PROXY`:

```python
TRUSTED_PROXY = environ.get("NOW_LMS_TRUSTED_PROXY") or None
```

and, only when it is set, passed through to `serve()` along with the specific headers to honor:

```python
if TRUSTED_PROXY:
    waitress_kwargs.update(
        trusted_proxy=TRUSTED_PROXY,
        trusted_proxy_headers={"x-forwarded-for", "x-forwarded-proto", "x-forwarded-host"},
        clear_untrusted_proxy_headers=True,
    )
```

Design choices worth flagging:

- **Opt-in, default `None`.** Unset reproduces today's behavior exactly, so this cannot change any existing deployment. Trusting a proxy by default would be a security regression — a client could spoof `X-Forwarded-Proto`.
- **An explicit header allow-list** rather than trusting everything the proxy sends, and `clear_untrusted_proxy_headers=True` is kept so anything outside that set is still stripped.
- **An env var** rather than a config-table setting, because it is needed before the app and database are up, and it is a property of the deployment topology rather than of the site.
- `"*"` is accepted to trust any proxy, which is the practical value when the app binds to loopback and only the proxy can reach it.

The `serve()` call is refactored into a `waitress_kwargs` dict so the conditional does not duplicate the argument list. Gunicorn is untouched — it already honors `X-Forwarded-*` via its own `forwarded_allow_ips`.

## Tests

`tests/test_run_trusted_proxy.py` (new, 2 tests): asserts the kwargs handed to `serve()` include `trusted_proxy` and the header allow-list when the variable is set, and that they are entirely absent when it is not — so the safe default is pinned, not just the new path.

```
$ pytest tests/test_run_trusted_proxy.py
2 passed
```

## Verification

- `pytest tests/test_run_trusted_proxy.py` → 2 passed.
- `ruff check now_lms` clean; `flake8` (project flags) clean; `pylint now_lms` 9.98/10 against the 9.5 gate; `black --check` clean on both touched files.
- Applies cleanly to current `main`.
- Same caveat as my other PR today: I could not get a clean full-suite baseline locally. `conftest.py`'s `sqlite:///:memory:` default errors in `init_app()` (`no such table: ad_sense`), and a single file database instead makes ~100 unrelated tests collide on `UNIQUE constraint failed: usuario.usuario`. Both reproduce on unmodified `main`, so they are unrelated to this change, but I am leaning on your CI for the full-suite signal.

## Risk

Low and bounded: no code path changes unless the new variable is set, and `run.py` is not imported by the app itself. Rolling back is reverting the commit; deployments that never set the variable are unaffected either way.

This pairs with the `ProxyFix` fix in my other PR — that one makes `FORCE_HTTPS` importable, this one makes it actually work behind a proxy — but the two are independent and can be taken in either order.

Commits are signed off per `docs/CONTRIBUTING.md`.