### PR TITLE
fix(assets): populate bundled frontend assets when node_modules is missing

### DIFF
--- a/now_lms/db/initial_data.py
+++ b/now_lms/db/initial_data.py
@@ -1639,11 +1639,18 @@ def populate_custmon_data_dir() -> None:
     from now_lms.config import DIRECTORIO_ARCHIVOS_BASE
 
     if DIRECTORIO_ARCHIVOS != DIRECTORIO_ARCHIVOS_BASE:
-        # Check if directory doesn't exist or is empty
+        # Populate when the data dir is missing/empty, OR when the bundled frontend assets
+        # (node_modules — Bootstrap etc.) are absent. The empty-only check never fires in
+        # practice: initial_setup() writes default-course files into the data dir before this
+        # runs, so the dir is already non-empty and node_modules was never copied, leaving the
+        # UI unstyled (Flask static_folder points at DIRECTORIO_ARCHIVOS). copytree(dirs_exist_ok
+        # =True) merges without clobbering existing uploads.
         should_populate = False
         try:
-            if not path.exists(DIRECTORIO_ARCHIVOS) or (
-                path.isdir(DIRECTORIO_ARCHIVOS) and len(listdir(DIRECTORIO_ARCHIVOS)) == 0
+            if (
+                not path.exists(DIRECTORIO_ARCHIVOS)
+                or (path.isdir(DIRECTORIO_ARCHIVOS) and len(listdir(DIRECTORIO_ARCHIVOS)) == 0)
+                or not path.exists(path.join(DIRECTORIO_ARCHIVOS, "node_modules"))
             ):
                 should_populate = True
         except OSError:

--- a/tests/test_populate_custom_data_dir_assets.py
+++ b/tests/test_populate_custom_data_dir_assets.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+"""
+Regression test for bundled frontend asset population with a custom data dir.
+
+With a custom NOW_LMS_DATA_DIR, Flask's static_folder points at that
+directory, so bundled frontend assets (node_modules — Bootstrap etc.) must be
+copied there or every static asset 404s and the UI renders unstyled.
+
+populate_custmon_data_dir() previously populated only when the data dir was
+missing or completely empty. That check never actually fires in the real
+boot sequence: initial_setup() writes default-course files into the data dir
+*before* this function runs, so by the time it's checked the directory is
+already non-empty — node_modules is never copied. The fix adds an explicit
+"node_modules is absent" check so a non-empty-but-unstyled data dir still
+gets populated, without disturbing files already there
+(copytree(dirs_exist_ok=True) merges).
+"""
+
+import importlib
+
+from now_lms.db import initial_data
+
+# now_lms/__init__.py defines its own module-level `config()` CLI function,
+# which shadows the `now_lms.config` submodule as a package attribute once
+# now_lms is imported — `import now_lms.config as config_module` would bind
+# to that function, not the submodule. importlib.import_module() always
+# resolves the real submodule regardless of that attribute shadowing.
+config_module = importlib.import_module("now_lms.config")
+
+
+def test_populates_bundled_assets_when_data_dir_is_nonempty_but_node_modules_is_missing(tmp_path, monkeypatch):
+    """The exact bug scenario: a custom data dir that already has files in it
+    (e.g. from initial_setup()'s default-course population) but never got the
+    bundled node_modules copied in."""
+    bundled_base = tmp_path / "bundled_base"
+    bundled_base.mkdir()
+    (bundled_base / "node_modules" / "bootstrap" / "dist").mkdir(parents=True)
+    (bundled_base / "node_modules" / "bootstrap" / "dist" / "bootstrap.min.css").write_text("/* bundled css */")
+
+    custom_data_dir = tmp_path / "custom_data"
+    custom_data_dir.mkdir()
+    (custom_data_dir / "examples").mkdir()
+    (custom_data_dir / "examples" / "already_uploaded.txt").write_text("pre-existing upload")
+
+    monkeypatch.setattr(initial_data, "DIRECTORIO_ARCHIVOS", str(custom_data_dir))
+    monkeypatch.setattr(config_module, "DIRECTORIO_ARCHIVOS_BASE", str(bundled_base))
+
+    initial_data.populate_custmon_data_dir()
+
+    copied_css = custom_data_dir / "node_modules" / "bootstrap" / "dist" / "bootstrap.min.css"
+    assert copied_css.exists(), "bundled node_modules assets must be copied even when the data dir is already non-empty"
+    assert copied_css.read_text() == "/* bundled css */"
+    # Existing uploads must survive the merge — this is not a destructive copy.
+    assert (custom_data_dir / "examples" / "already_uploaded.txt").read_text() == "pre-existing upload"
+
+
+def test_does_not_touch_data_dir_when_it_matches_the_bundled_base(tmp_path, monkeypatch):
+    """Sanity control: when DIRECTORIO_ARCHIVOS == DIRECTORIO_ARCHIVOS_BASE
+    (no custom data dir configured), the function must be a no-op — proves
+    the previous test is exercising the "custom dir" branch, not a
+    default-path coincidence."""
+    same_dir = tmp_path / "same"
+    same_dir.mkdir()
+
+    monkeypatch.setattr(initial_data, "DIRECTORIO_ARCHIVOS", str(same_dir))
+    monkeypatch.setattr(config_module, "DIRECTORIO_ARCHIVOS_BASE", str(same_dir))
+
+    initial_data.populate_custmon_data_dir()
+
+    assert list(same_dir.iterdir()) == []


### PR DESCRIPTION
## Problem

Under a custom `NOW_LMS_DATA_DIR`, the bundled frontend assets are never copied, so every static asset 404s and the UI renders unstyled.

`populate_custmon_data_dir()` in `now_lms/db/initial_data.py:1637` only populates when the target directory is missing or empty:

```python
if not path.exists(DIRECTORIO_ARCHIVOS) or (
    path.isdir(DIRECTORIO_ARCHIVOS) and len(listdir(DIRECTORIO_ARCHIVOS)) == 0
):
    should_populate = True
```

That guard never fires in practice. `initial_setup()` writes default-course files into the data directory *before* this function runs, so by the time it is reached the directory is already non-empty — while `node_modules` (Bootstrap and the rest of the vendored frontend) has never been copied. Flask's `static_folder` points at `DIRECTORIO_ARCHIVOS`, so the app comes up with every stylesheet and script 404ing.

The emptiness check is a reasonable proxy for "has this been set up yet?", but it is measuring the wrong thing — the question is whether the *assets* are present, not whether the directory has anything in it at all.

## Fix

Add the actual condition being cared about:

```python
if (
    not path.exists(DIRECTORIO_ARCHIVOS)
    or (path.isdir(DIRECTORIO_ARCHIVOS) and len(listdir(DIRECTORIO_ARCHIVOS)) == 0)
    or not path.exists(path.join(DIRECTORIO_ARCHIVOS, "node_modules"))
):
    should_populate = True
```

The existing `copytree(..., dirs_exist_ok=True)` already merges rather than replaces, so re-running is safe and **user uploads already in the directory are not clobbered** — that is why extending the guard is enough and no copy logic changes.

Checking for `node_modules` specifically, rather than adding a marker file or a version stamp, keeps the check honest about the failure being fixed and needs no new state. A marker file would also lie after a partial or interrupted copy.

## Tests

`tests/test_populate_custom_data_dir_assets.py` (new, 2 tests): the regression case is a data directory that is non-empty but has no `node_modules` — the exact post-`initial_setup()` state — asserting the assets get populated; plus a case asserting existing files in the directory survive the copy.

```
$ pytest tests/test_populate_custom_data_dir_assets.py
2 passed
```

## Verification

- `pytest tests/test_populate_custom_data_dir_assets.py` → 2 passed.
- `ruff check now_lms` clean; `flake8` (project flags) clean; `pylint now_lms` 9.98/10 against the 9.5 gate; `black --check` clean on both touched files.
- Found on a real deployment using a custom data directory; the site served with no styling until this was patched.
- Full-suite caveat, same as my other PRs today: `conftest.py`'s `sqlite:///:memory:` default errors in `init_app()` (`no such table: ad_sense`) and a single file database makes ~100 unrelated tests collide on `UNIQUE constraint failed: usuario.usuario`. Both reproduce on unmodified `main`, so they are unrelated to this change — relying on your CI for the full-suite signal.

## Risk

Low. The only behavior change is that a copy now also happens in a case where it previously did not, and that copy is already idempotent and non-destructive. Deployments using the default data directory never enter the branch at all (`DIRECTORIO_ARCHIVOS != DIRECTORIO_ARCHIVOS_BASE` gates the whole function). The cost is one extra `path.exists()` per startup.

Commits are signed off per `docs/CONTRIBUTING.md`.