### PR TITLE
fix(dev): drop the dangling ensure_headers.py call from dev/lint.sh

### DIFF
--- a/dev/lint.sh
+++ b/dev/lint.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 echo -------------------------------------------------
-echo Ensure company headers in Python files
-echo -------------------------------------------------
-echo
-python dev/ensure_headers.py --apply --paths now_lms,tests
-echo -------------------------------------------------
 echo Format Python code
 echo -------------------------------------------------
 echo


### PR DESCRIPTION
## Problem

`dev/lint.sh` — the lint command `docs/CONTRIBUTING.md` points contributors at — opens by running a file that is not in the repository:

```bash
python dev/ensure_headers.py --apply --paths now_lms,tests
```

Commit `61f73d8` ("clean", 2026-02-01) deleted `dev/ensure_headers.py` (133 lines) but left the call site untouched, so the reference has been dangling for roughly six months. `git grep ensure_headers` on `main` returns exactly this one line.

What a new contributor sees as the very first output of the documented lint command:

```
-------------------------------------------------
Ensure company headers in Python files
-------------------------------------------------

python: can't open file '/.../dev/ensure_headers.py': [Errno 2] No such file or directory
```

exit status 2. `dev/lint.sh` has no `set -e`, so the black/pylint/prettier steps below still run and the script exits 0 overall — it is noise rather than a hard stop. But it is the first thing a newcomer sees after following the setup guide, and there is no way to tell from that message whether their environment is misconfigured or the repo is. It is a small thing that reads like a broken project, on a setup that is otherwise smooth.

## Fix

Remove the orphaned step.

I chose removal over restoring the script because `61f73d8` deleted `ensure_headers.py` deliberately — the commit is titled "clean" and removes only that file. Dropping the leftover invocation completes that cleanup. Re-adding a header-stamping tool would be a new feature decision rather than a fix, and belongs in its own change if you want it back; I did not want to make that call on your behalf.

No other file references the script, so nothing else needs updating.

## Verification

```
$ bash -n dev/lint.sh          # parses
$ shellcheck dev/lint.sh       # clean, no output
```

The script now begins at the black step and produces no error output. The `black`, `pylint`, and `prettier` steps are unchanged and still run in the same order.

## Risk

None to the application — this is a developer script, not shipped code. Nothing imports it and no CI workflow calls it (`.github/workflows` invokes its tools directly). The only behavioral change is that one failing command no longer runs.

Commits are signed off per `docs/CONTRIBUTING.md`.