### PR TITLE
fix(mail): coerce MAIL_USE_TLS/MAIL_USE_SSL to booleans so the match arms fire

### DIFF
--- a/now_lms/mail.py
+++ b/now_lms/mail.py
@@ -64,18 +64,27 @@ def _load_mail_config_from_env() -> SimpleNamespace:
     # Default sender
     mail_default_sender = environ.get("MAIL_DEFAULT_SENDER")
 
-    # String to boolean conversion using pattern matching
+    # String to boolean conversion using pattern matching.
+    # str.capitalize() yields "True"/"False", so the arms must match that exact
+    # casing — the previous all-caps arms ("TRUE"/"FALSE") never matched, the
+    # values stayed non-empty strings, and both flags read as enabled
+    # simultaneously (every non-empty string is truthy). The wildcard arm makes
+    # any unrecognized value an explicit False instead of a truthy string.
     match mail_use_ssl:
-        case "FALSE":
+        case "False":
             mail_use_ssl = False  # type: ignore[assignment]
-        case "TRUE":
+        case "True":
             mail_use_ssl = True  # type: ignore[assignment]
+        case _:
+            mail_use_ssl = False  # type: ignore[assignment]
 
     match mail_use_tls:
-        case "FALSE":
+        case "False":
             mail_use_tls = False  # type: ignore[assignment]
-        case "TRUE":
+        case "True":
             mail_use_tls = True  # type: ignore[assignment]
+        case _:
+            mail_use_tls = False  # type: ignore[assignment]
 
     return SimpleNamespace(
         mail_configured=is_mail_configured,

--- a/tests/test_mail_config.py
+++ b/tests/test_mail_config.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+"""Regression tests for MAIL_USE_TLS / MAIL_USE_SSL boolean coercion.
+
+The env loader capitalizes the raw value (str.capitalize() -> "True"/"False")
+and then pattern-matches it to a real boolean. The original match arms compared
+against all-caps "TRUE"/"FALSE", which str.capitalize() can never produce, so
+the values stayed non-empty strings — and every non-empty string is truthy,
+meaning MAIL_USE_TLS=False and MAIL_USE_SSL=False both read as *enabled* and
+Flask-Mail picked SSL on a STARTTLS port. These tests pin the fixed behavior
+for every spelling a .env file plausibly contains.
+"""
+
+import pytest
+
+from now_lms.mail import _load_mail_config_from_env
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("TRUE", True),
+        ("False", False),
+        ("false", False),
+        ("FALSE", False),
+        ("", False),  # empty string must not read as enabled
+        ("yes", False),  # unrecognized values are an explicit False, never a truthy string
+        ("1", False),
+    ],
+)
+def test_mail_use_tls_coerces_to_real_boolean(monkeypatch, raw, expected):
+    monkeypatch.setenv("MAIL_USE_TLS", raw)
+    monkeypatch.delenv("MAIL_USE_SSL", raising=False)
+    config = _load_mail_config_from_env()
+    assert config.MAIL_USE_TLS is expected
+    assert config.MAIL_USE_SSL is False
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("True", True),
+        ("TRUE", True),
+        ("False", False),
+        ("FALSE", False),
+    ],
+)
+def test_mail_use_ssl_coerces_to_real_boolean(monkeypatch, raw, expected):
+    monkeypatch.setenv("MAIL_USE_SSL", raw)
+    monkeypatch.delenv("MAIL_USE_TLS", raising=False)
+    config = _load_mail_config_from_env()
+    assert config.MAIL_USE_SSL is expected
+
+
+def test_tls_and_ssl_are_never_both_truthy_by_default(monkeypatch):
+    """The original bug: with neither var set, BOTH flags read as enabled."""
+    monkeypatch.delenv("MAIL_USE_TLS", raising=False)
+    monkeypatch.delenv("MAIL_USE_SSL", raising=False)
+    config = _load_mail_config_from_env()
+    assert config.MAIL_USE_TLS is False
+    assert config.MAIL_USE_SSL is False


### PR DESCRIPTION
Cherry-picked from #223 (by @jeremylongshore).

## What

`_load_mail_config_from_env()` in `now_lms/mail.py` calls `str.capitalize()` on the env value — which produces `"True"` / `"False"` — and then pattern-matches it against `"TRUE"` / `"FALSE"`. Those arms can never match, so both values stay non-empty strings — and every non-empty string is truthy, meaning `MAIL_USE_TLS=False` and `MAIL_USE_SSL=False` are BOTH read as enabled at the same time.

## Fix

Match on what `capitalize()` actually produces, and add a wildcard arm so an unrecognised value becomes an explicit `False` instead of a truthy string.

## Verification

Adds `tests/test_mail_config.py` — 14 parametrized cases covering the spellings a `.env` plausibly contains, plus the both-unset default that demonstrated the original bug.