### PR TITLE
fix(access): grant free-course access when the enrollment has no payment record

### DIFF
--- a/now_lms/db/tools.py
+++ b/now_lms/db/tools.py
@@ -106,6 +106,15 @@ def verifica_estudiante_asignado_a_curso(id_curso: str | None = None) -> bool:
                 if pago.estado == "completed" or pago.audit:
                     return True
                 return False
+            # An enrollment with no Pago row is legitimate on a FREE course: the
+            # admin enrollment routes and any bulk/scripted enrollment create
+            # EstudianteCurso with pago=None. Requiring a payment record here
+            # locked those students out of courses they are enrolled in, because
+            # this helper is what `permitir_estudiante` and the resource routes
+            # gate on. Paid courses still require a completed or audit payment.
+            curso = database.session.execute(database.select(Curso).filter(Curso.codigo == id_curso)).scalars().first()
+            if curso is not None and not curso.pagado:
+                return True
             return False
         return False
     return False

--- a/tests/test_free_course_access.py
+++ b/tests/test_free_course_access.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Access checks for enrollments that carry no payment record.
+
+``verifica_estudiante_asignado_a_curso`` is what ``permitir_estudiante`` and the
+resource routes gate on. Admin-created and bulk/scripted enrollments produce an
+``EstudianteCurso`` row with ``pago=None``; on a free course those students must
+still get access. Paid courses must keep requiring a completed or audit payment.
+"""
+
+from now_lms.db import Curso, EstudianteCurso, Pago, Usuario, database
+from now_lms.db.tools import verifica_estudiante_asignado_a_curso
+
+
+def _course(code, *, pagado):
+    return Curso(
+        nombre=f"Course {code}",
+        codigo=code,
+        descripcion="Course used by the free-course access tests.",
+        descripcion_corta="Access test course.",
+        estado="open",
+        publico=False,
+        pagado=pagado,
+        precio=100 if pagado else 0,
+        auditable=False,
+        certificado=False,
+        modalidad="self_paced",
+        creado_por="test",
+    )
+
+
+def _student(username):
+    return Usuario(
+        usuario=username,
+        acceso=b"x",
+        nombre="Access",
+        apellido="Test",
+        correo_electronico=f"{username}@example.test",
+        tipo="student",
+        activo=True,
+        correo_electronico_verificado=True,
+        creado_por="test",
+    )
+
+
+def _enroll(course_code, username, pago_id=None):
+    return EstudianteCurso(curso=course_code, usuario=username, vigente=True, pago=pago_id, creado_por="test")
+
+
+def test_free_course_enrollment_without_payment_grants_access(app):
+    """The regression: pago=None on a free course must NOT lock the student out."""
+    with app.app_context():
+        s = database.session
+        s.add(_course("FREENP", pagado=False))
+        s.add(_student("free-nopago"))
+        s.flush()
+        s.add(_enroll("FREENP", "free-nopago", pago_id=None))
+        s.commit()
+
+        with app.test_request_context():
+            from flask_login import login_user
+
+            login_user(s.execute(database.select(Usuario).filter_by(usuario="free-nopago")).scalars().one())
+            assert verifica_estudiante_asignado_a_curso("FREENP") is True
+
+
+def test_paid_course_enrollment_without_payment_denies_access(app):
+    """The boundary: a paid course still requires a payment record."""
+    with app.app_context():
+        s = database.session
+        s.add(_course("PAIDNP", pagado=True))
+        s.add(_student("paid-nopago"))
+        s.flush()
+        s.add(_enroll("PAIDNP", "paid-nopago", pago_id=None))
+        s.commit()
+
+        with app.test_request_context():
+            from flask_login import login_user
+
+            login_user(s.execute(database.select(Usuario).filter_by(usuario="paid-nopago")).scalars().one())
+            assert verifica_estudiante_asignado_a_curso("PAIDNP") is False
+
+
+def test_paid_course_with_completed_payment_grants_access(app):
+    """Unchanged behaviour: completed payment on a paid course still works."""
+    with app.app_context():
+        s = database.session
+        s.add(_course("PAIDOK", pagado=True))
+        s.add(_student("paid-ok"))
+        s.flush()
+        pago = Pago(
+            usuario="paid-ok",
+            curso="PAIDOK",
+            nombre="Access",
+            apellido="Test",
+            correo_electronico="paid-ok@example.test",
+            monto=100,
+            estado="completed",
+            audit=False,
+            creado_por="test",
+        )
+        s.add(pago)
+        s.flush()
+        s.add(_enroll("PAIDOK", "paid-ok", pago_id=pago.id))
+        s.commit()
+
+        with app.test_request_context():
+            from flask_login import login_user
+
+            login_user(s.execute(database.select(Usuario).filter_by(usuario="paid-ok")).scalars().one())
+            assert verifica_estudiante_asignado_a_curso("PAIDOK") is True
+
+
+def test_not_enrolled_denies_access(app):
+    """Unchanged behaviour: no enrollment row means no access, free course or not."""
+    with app.app_context():
+        s = database.session
+        s.add(_course("FREENE", pagado=False))
+        s.add(_student("not-enrolled"))
+        s.commit()
+
+        with app.test_request_context():
+            from flask_login import login_user
+
+            login_user(s.execute(database.select(Usuario).filter_by(usuario="not-enrolled")).scalars().one())
+            assert verifica_estudiante_asignado_a_curso("FREENE") is False


### PR DESCRIPTION
## The bug

`verifica_estudiante_asignado_a_curso()` (`now_lms/db/tools.py`) requires the enrollment's `Pago` row to exist and be `completed`/`audit` before granting access — with no exception for free courses:

```python
if regitro:
    pago = ...filter(Pago.id == regitro.pago)...first()
    if pago:
        if pago.estado == "completed" or pago.audit:
            return True
        return False
    return False   # <-- pago is None: denied, even on a free course
```

But an enrollment with `pago=None` is perfectly legitimate: the admin enrollment routes and any bulk or scripted enrollment create `EstudianteCurso` rows without a payment. On a **free** course those students are then locked out of a course they are enrolled in.

## Why it's easy to miss

This helper is what the template gate reads — `learning/curso.html` line 3 sets `permitir_estudiante = ln(id_curso=curso.codigo)` from it, which overrides anything a route passes. So the affected student gets a **200 page that looks fine**: the course outline renders, but every lesson link is suppressed and an "Enroll in the course" button appears instead. Clicking it adds another `EstudianteCurso` row and still grants no access, so the student can stack duplicate enrollments while remaining locked out. Nothing errors and nothing logs.

We hit this on a deployment with a cohort of bulk-enrolled students: every one of them was locked out of both free courses, with zero evaluation attempts recorded, and the symptom presented as "I enrolled but can't access the course."

## The fix

Nine lines: when there is no `Pago` and `Curso.pagado` is false, grant access.

Paid courses are deliberately untouched — a paid course with no payment still returns `False`, and `completed`/`audit` still behave exactly as before.

## Tests

The helper had no direct coverage, so this adds `tests/test_free_course_access.py` with four cases:

| Case | Expected |
|---|---|
| free course, `pago=None` | `True` ← the regression |
| paid course, `pago=None` | `False` ← the boundary |
| paid course, completed payment | `True` (unchanged) |
| not enrolled at all | `False` (unchanged) |

**Mutation-checked:** with the fix reverted, the regression test fails (`assert False is True`) and the other three still pass — so they are exercising the behaviour, not rubber-stamping it.

```
$ pytest tests/test_free_course_access.py -q
....                                       [100%]
```

ruff + flake8 clean; `pylint now_lms/db/tools.py` → **10.00/10**.

## Scope

One behavioural change in one function, plus a new test file. Branched from `main` at v2.0.1 (`6baac92`). Deliberately excludes two adjacent items so this stays reviewable on its own: filtering the enrollment lookup on `vigente` (a separate correctness question) and passing `permitir_estudiante` explicitly from the take/moderate routes (redundant while the template sets it).

- Jeremy Longshore
intentsolutions.io