### PR TITLE
fix(enroll): render the country field as a text input, not an empty select

### DIFF
--- a/now_lms/templates/learning/curso/enroll.html
+++ b/now_lms/templates/learning/curso/enroll.html
@@ -117,7 +117,7 @@
                                 </div>
                                 <div class="col-md-5">
                                     <label for="pais" class="form-label">{{ _('País') }}</label>
-                                    {{ form.pais(class="form-select", id="pais") }} {{ render_field_errors(form.pais) }}
+                                    {{ form.pais(class="form-control", id="pais") }} {{ render_field_errors(form.pais) }}
                                     <div class="invalid-feedback">{{ _('Please select a valid country.') }}</div>
                                 </div>
                                 <div class="col-md-4">


### PR DESCRIPTION
## The bug

`PagoForm.pais` is a `StringField` (`now_lms/forms/__init__.py:894`), but the enrollment template renders it with Bootstrap's select styling (`templates/learning/curso/enroll.html:120`):

```jinja
{{ form.pais(class="form-select", id="pais") }}
```

WTForms renders a `StringField` as `<input type="text">`, so `form-select` produces a control that *looks* like a dropdown — select padding, select height — but has no options and no caret. To anyone filling out the enrollment form, the country field reads as a broken dropdown.

Every sibling field in the same form (`nombre`, `apellido`, `correo_electronico`, `direccion1`, `direccion2`, `provincia`, `codigo_postal`) uses `form-control`. `pais` was the only one styled as a select.

## The fix

One character: `form-select` → `form-control`, matching the siblings.

I chose that over converting `pais` to a `SelectField` with a country list, because a country dropdown is a **feature** — and one with an i18n question attached (~250 translated country names, which would want a `get_*_choices()` helper like `get_nivel_choices()`). Happy to submit that separately if you'd prefer the dropdown; this PR just stops the field from being visibly broken.

## Verification

Rendered the real enrollment page for an authenticated student on a free course:

**Before** — `class="form-select"` on a text input.

**After:**
```html
<input class="form-control" id="pais" name="pais" required type="text" value="">
```

Also swept every template for the same class of mismatch — a `StringField` rendered with `form-select` — and found no other instances.

## Scope

One line, one template. No form, model, route, or validation change; `DataRequired()` on `pais` is untouched.

- Jeremy Longshore
intentsolutions.io