### PR TITLE
fix(enroll): stop requiring a billing address for free enrollments

### DIFF
--- a/now_lms/forms/__init__.py
+++ b/now_lms/forms/__init__.py
@@ -884,16 +884,41 @@ class ResetPasswordForm(FlaskForm):
 
 
 class PagoForm(FlaskForm):
-    """Formulario para crear un pago."""
+    """Formulario para crear un pago.
+
+    The billing-address fields are only required when there is actually
+    something to bill. Set ``requires_billing = False`` (see
+    ``vistas/courses/enrollment.py``) for a free or fully-discounted
+    enrollment; the template then hides those fields and the form still
+    validates. Paid enrollments keep requiring a full address.
+    """
 
     nombre = StringField(validators=[DataRequired()])
     apellido = StringField(validators=[DataRequired()])
     correo_electronico = StringField(validators=[DataRequired()])
-    direccion1 = StringField(validators=[DataRequired()])
+    direccion1 = StringField(validators=[Optional()])
     direccion2 = StringField()
-    pais = StringField(validators=[DataRequired()])
-    provincia = StringField(validators=[DataRequired()])
-    codigo_postal = StringField(validators=[DataRequired()])
+    pais = StringField(validators=[Optional()])
+    provincia = StringField(validators=[Optional()])
+    codigo_postal = StringField(validators=[Optional()])
+
+    #: Whether this submission must carry a billing address. The route sets it
+    #: from ``Curso.pagado`` before validating.
+    requires_billing = True
+
+    def validate(self, extra_validators=None) -> bool:
+        """Validate, enforcing the billing address only when it is required."""
+        valid = super().validate(extra_validators)
+
+        if not self.requires_billing:
+            return valid
+
+        for field in (self.direccion1, self.pais, self.provincia, self.codigo_postal):
+            if not (field.data or "").strip():
+                field.errors = list(field.errors) + [_("Este campo es obligatorio.")]
+                valid = False
+
+        return valid
 
 
 # ---------------------------------------------------------------------------------------

--- a/now_lms/templates/learning/curso/enroll.html
+++ b/now_lms/templates/learning/curso/enroll.html
@@ -83,7 +83,9 @@
                             </ul>
                         </div>
                         <div class="col-md-7 col-lg-8">
-                            <h4 class="mb-3">{{ _('Billing address') }}</h4>
+                            <h4 class="mb-3">
+                                {% if form.requires_billing %}{{ _('Billing address') }}{% else %}{{ _('Sus datos') }}{% endif %}
+                            </h4>
                             <div class="row g-3">
                                 <div class="col-sm-6">
                                     <label for="nombre" class="form-label">{{ _('Nombre') }}</label>
@@ -104,6 +106,8 @@
                                         {{ _('Please enter a valid email address for shipping updates.') }}
                                     </div>
                                 </div>
+                                {# Billing address: only collected when there is something to bill. #}
+                                {% if form.requires_billing %}
                                 <div class="col-12">
                                     <label for="dirrecion1" class="form-label">{{ _('Dirección') }}</label>
                                     {{ form.direccion1(class="form-control", id="dirrecion1") }} {{
@@ -132,6 +136,7 @@
                                     render_field_errors(form.codigo_postal) }}
                                     <div class="invalid-feedback">{{ _('Zip code required.') }}</div>
                                 </div>
+                                {% endif %}
                             </div>
 
                             {% if curso.pagado %}

--- a/now_lms/vistas/courses/enrollment.py
+++ b/now_lms/vistas/courses/enrollment.py
@@ -244,6 +244,10 @@ def course_enroll(course_code: str) -> str | Response:
         flash(pricing.validation_error, "warning")
 
     form = PagoForm()
+    # A free (or fully-discounted) enrollment has nothing to bill, so the
+    # billing address is neither collected nor required. The template hides
+    # those fields for the same condition.
+    form.requires_billing = not _is_free_enrollment(_curso, pricing.final_price)
     coupon_form = CouponApplicationForm()
 
     # Pre-fill form data only on GET requests to avoid overwriting user submission on POST

--- a/tests/test_free_enrollment_no_billing.py
+++ b/tests/test_free_enrollment_no_billing.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""A free enrollment must not demand a billing address.
+
+``PagoForm`` gates the address fields on ``requires_billing``, which
+``course_enroll`` sets from whether the enrollment actually costs anything.
+Free courses therefore enroll with name + email alone; paid courses keep
+requiring a full address.
+"""
+
+from now_lms.auth import proteger_passwd
+from now_lms.db import Curso, EstudianteCurso, Usuario, database
+from now_lms.forms import PagoForm
+
+PASSWORD = "billing-test-pw-123"
+
+
+def _course(app, code, *, pagado):
+    with app.app_context():
+        s = database.session
+        s.add(
+            Curso(
+                nombre=f"Course {code}",
+                codigo=code,
+                descripcion="Billing-requirement test course.",
+                descripcion_corta="Billing test.",
+                estado="open",
+                publico=True,
+                pagado=pagado,
+                precio=100 if pagado else 0,
+                auditable=False,
+                certificado=False,
+                modalidad="self_paced",
+                creado_por="test",
+            )
+        )
+        s.commit()
+
+
+def _student(app, username):
+    with app.app_context():
+        s = database.session
+        s.add(
+            Usuario(
+                usuario=username,
+                acceso=proteger_passwd(PASSWORD),
+                nombre="Billing",
+                apellido="Test",
+                correo_electronico=f"{username}@example.test",
+                tipo="student",
+                activo=True,
+                correo_electronico_verificado=True,
+                creado_por="test",
+            )
+        )
+        s.commit()
+
+
+def _login(client, username):
+    return client.post("/user/login", data={"usuario": username, "acceso": PASSWORD}, follow_redirects=False)
+
+
+def test_free_course_form_does_not_require_billing(app):
+    """The form itself validates with no address when billing is not required."""
+    with app.test_request_context(
+        "/course/X/enroll",
+        method="POST",
+        data={"nombre": "A", "apellido": "B", "correo_electronico": "a@b.test"},
+    ):
+        form = PagoForm()
+        form.requires_billing = False
+        assert form.validate() is True, form.errors
+
+
+def test_paid_course_form_still_requires_billing(app):
+    """The boundary: with billing required, a missing address fails validation."""
+    with app.test_request_context(
+        "/course/X/enroll",
+        method="POST",
+        data={"nombre": "A", "apellido": "B", "correo_electronico": "a@b.test"},
+    ):
+        form = PagoForm()
+        form.requires_billing = True
+        assert form.validate() is False
+        for field in ("direccion1", "pais", "provincia", "codigo_postal"):
+            assert form.errors.get(field), f"{field} should be flagged as required"
+
+
+def test_paid_course_form_accepts_a_full_address(app):
+    """Unchanged behaviour: a complete address validates on a paid course."""
+    with app.test_request_context(
+        "/course/X/enroll",
+        method="POST",
+        data={
+            "nombre": "A",
+            "apellido": "B",
+            "correo_electronico": "a@b.test",
+            "direccion1": "1 Main St",
+            "pais": "Nicaragua",
+            "provincia": "Managua",
+            "codigo_postal": "10001",
+        },
+    ):
+        form = PagoForm()
+        form.requires_billing = True
+        assert form.validate() is True, form.errors
+
+
+def test_free_enrollment_page_hides_the_address_fields(app, client):
+    """The rendered free-course page must not ask for an address at all."""
+    _course(app, "FREEBIL", pagado=False)
+    _student(app, "free-billing@example.test")
+    _login(client, "free-billing@example.test")
+
+    body = client.get("/course/FREEBIL/enroll").get_data(as_text=True)
+    assert 'id="nombre"' in body
+    assert 'id="dirrecion1"' not in body
+    assert 'id="pais"' not in body
+    assert 'id="codigo_postal"' not in body
+
+
+def test_free_enrollment_succeeds_without_an_address(app, client):
+    """End to end: posting name + email alone enrolls the student."""
+    _course(app, "FREEPOST", pagado=False)
+    _student(app, "free-post@example.test")
+    _login(client, "free-post@example.test")
+
+    client.post(
+        "/course/FREEPOST/enroll",
+        data={"nombre": "Billing", "apellido": "Test", "correo_electronico": "free-post@example.test"},
+        follow_redirects=False,
+    )
+
+    with app.app_context():
+        enrollment = (
+            database.session.execute(
+                database.select(EstudianteCurso).filter_by(curso="FREEPOST", usuario="free-post@example.test")
+            )
+            .scalars()
+            .first()
+        )
+        assert enrollment is not None, "free enrollment should have been created without a billing address"


### PR DESCRIPTION
## The bug

A **free** course asks for a full postal address before it will enroll anyone.

`PagoForm` marks the address fields `DataRequired()` unconditionally (`now_lms/forms/__init__.py`):

```python
direccion1 = StringField(validators=[DataRequired()])
pais = StringField(validators=[DataRequired()])
provincia = StringField(validators=[DataRequired()])
codigo_postal = StringField(validators=[DataRequired()])
```

…and `templates/learning/curso/enroll.html` renders the **Billing address** block for every course, paid or not. So a student joining a course that costs nothing must supply a street address, country, state and zip — and the summary panel next to those fields is simultaneously showing **GRATIS**.

## The fix

`PagoForm` gains a `requires_billing` flag, and `course_enroll` sets it from `_is_free_enrollment()` — the helper the route *already* uses to decide whether to take a payment:

```python
form.requires_billing = not _is_free_enrollment(_curso, pricing.final_price)
```

The four address fields become `Optional()` and are enforced in `validate()` only when the flag is set. The template hides the address inputs on the same condition and titles the section *Sus datos* instead of *Billing address*.

This also covers the coupon case for free: a 100%-discount coupon makes `final_price == 0`, so that enrollment stops demanding an address too.

**Paid courses are unchanged** — `requires_billing` stays `True`, the fields render, and a missing address still fails validation.

I chose a form-level flag over a slimmer second form class because `_build_pago_from_form()` reads the address attributes straight off the form; a class without them would have needed `getattr()` guards in the payment path — more surface for the same outcome.

## Verification

New `tests/test_free_enrollment_no_billing.py`, 5 cases:

| Case | Expected |
|---|---|
| form validates, no address, billing off | pass |
| form rejects missing address, billing on | fail with per-field errors |
| form accepts a full address, billing on | pass (unchanged) |
| rendered free page omits the address inputs | no `dirrecion1` / `pais` / `codigo_postal` |
| POST name + email alone on a free course | `EstudianteCurso` row created |

```
$ pytest tests/test_free_enrollment_no_billing.py -q
.....                                       [100%]
```

**Mutation-checked:** with all three source changes reverted, **3 of the 5 fail** — including the end-to-end enrollment (`assert None is not None`: no enrollment created) — while the two paid-course cases stay green, so they are genuinely guarding the paid path.

**Regression check:** `tests/test_coupons.py` — the form's other consumer — passes 11/11.

ruff + flake8 clean; `pylint` **10.00/10** on both changed modules.

## Scope and what I left out

Three source files (form, route, template) + one test file. Branched from `main` at v2.0.1 (`6baac92`).

Deliberately **not** included, to keep this reviewable: the enrollment routes have **no duplicate-enrollment guard**, so a student already enrolled can submit this form again and get a second `EstudianteCurso` row plus another `Pago`. I hit that in practice and can send it separately if you'd like it fixed.

- Jeremy Longshore
intentsolutions.io