### PR TITLE
fix(i18n): make form labels lazy and keep them extractable

### DIFF
--- a/dev/lang.sh
+++ b/dev/lang.sh
@@ -1,6 +1,10 @@
 # Actualizar archivo de traducción
 # Extraer nuevos textos
-pybabel extract -F babel.cfg -o now_lms/translations/messages.pot .
+#
+# -k _l es obligatorio: `_l` (lazy_gettext) no está en las palabras clave por
+# defecto de Babel, así que sin esta opción las etiquetas de formulario escritas
+# con _l() no se extraen y quedan imposibles de traducir.
+pybabel extract -F babel.cfg -k _l -o now_lms/translations/messages.pot .
 
 # Actualizar archivos de idioma
 pybabel update -i now_lms/translations/messages.pot -d now_lms/translations

--- a/dev/lang.sh
+++ b/dev/lang.sh
@@ -1,10 +1,12 @@
 # Actualizar archivo de traducción
 # Extraer nuevos textos
 #
-# -k _l es obligatorio: `_l` (lazy_gettext) no está en las palabras clave por
-# defecto de Babel, así que sin esta opción las etiquetas de formulario escritas
-# con _l() no se extraen y quedan imposibles de traducir.
-pybabel extract -F babel.cfg -k _l -o now_lms/translations/messages.pot .
+# Los alias propios del proyecto no están en las palabras clave por defecto de
+# Babel, así que hay que declararlos o sus textos no se extraen y quedan
+# imposibles de traducir:
+#   -k _l        -> _l() / lazy_gettext, las etiquetas de formulario
+#   -k _n:1,2    -> _n() / ngettext, singular y plural
+pybabel extract -F babel.cfg -k _l -k _n:1,2 -o now_lms/translations/messages.pot .
 
 # Actualizar archivos de idioma
 pybabel update -i now_lms/translations/messages.pot -d now_lms/translations

--- a/now_lms/forms/__init__.py
+++ b/now_lms/forms/__init__.py
@@ -29,6 +29,7 @@ from wtforms import (
     TextAreaField,
     TimeField,
 )
+from flask_babel import LazyString
 from wtforms.validators import DataRequired, Length, Optional, ValidationError
 from wtforms.widgets import ColorInput, TextArea, html_params
 
@@ -346,7 +347,10 @@ def get_reveal_theme_choices() -> list[tuple[str, str]]:
 
 
 # Form label constants
-LABEL_TITULO: str = _("Título")
+# Shared field label. Lazy like every other form label: this constant is
+# evaluated at import time, so _() would freeze one locale for every form that
+# reuses it.
+LABEL_TITULO: LazyString = _l("Título")
 
 
 # ---------------------------------------------------------------------------------------
@@ -359,25 +363,25 @@ class ConfigForm(FlaskForm):
     descripcion = StringField(validators=[DataRequired()])
 
     # Localización
-    moneda = SelectField(_("Moneda"), choices=[], validators=[])
+    moneda = SelectField(_l("Moneda"), choices=[], validators=[])
     lang = SelectField(
-        _("Idioma"), choices=[("es", "Español"), ("en", "English"), ("pt_BR", "Português do Brasil")], validators=[]
+        _l("Idioma"), choices=[("es", "Español"), ("en", "English"), ("pt_BR", "Português do Brasil")], validators=[]
     )
-    timezone = SelectField(_("Zona Horaria"), choices=[], validators=[])
+    timezone = SelectField(_l("Zona Horaria"), choices=[], validators=[])
 
     verify_user_by_email = BooleanField(validators=[])
     allow_unverified_email_login = BooleanField(validators=[])
 
     # Navigation configuration
-    enable_programs = BooleanField(_("Habilitar Programas"), default=False, validators=[])
-    enable_masterclass = BooleanField(_("Habilitar Master Class"), default=False, validators=[])
-    enable_resources = BooleanField(_("Habilitar Recursos descargables"), default=False, validators=[])
-    enable_blog = BooleanField(_("Habilitar Blog"), default=False, validators=[])
-    enable_contact = BooleanField(_("Habilitar Contacto"), default=False, validators=[])
+    enable_programs = BooleanField(_l("Habilitar Programas"), default=False, validators=[])
+    enable_masterclass = BooleanField(_l("Habilitar Master Class"), default=False, validators=[])
+    enable_resources = BooleanField(_l("Habilitar Recursos descargables"), default=False, validators=[])
+    enable_blog = BooleanField(_l("Habilitar Blog"), default=False, validators=[])
+    enable_contact = BooleanField(_l("Habilitar Contacto"), default=False, validators=[])
 
     # Blog display configuration
     show_latest_blog_posts_on_home = BooleanField(
-        _("Mostrar últimas entradas del blog en página de inicio"), default=False, validators=[]
+        _l("Mostrar últimas entradas del blog en página de inicio"), default=False, validators=[]
     )
 
     # Custom information
@@ -394,31 +398,31 @@ class ConfigForm(FlaskForm):
     custom_text4 = StringField(validators=[])
 
     # File upload configuration
-    enable_file_uploads = BooleanField(_("Habilitar subida de archivos descargables"), default=False, validators=[])
-    max_file_size = IntegerField(_("Tamaño máximo de archivo (MB)"), default=1, validators=[])
+    enable_file_uploads = BooleanField(_l("Habilitar subida de archivos descargables"), default=False, validators=[])
+    max_file_size = IntegerField(_l("Tamaño máximo de archivo (MB)"), default=1, validators=[])
 
     # HTML preformatted descriptions configuration
     enable_html_preformatted_descriptions = BooleanField(
-        _("Permitir HTML preformateado en la descripción de recursos"), default=False, validators=[]
+        _l("Permitir HTML preformateado en la descripción de recursos"), default=False, validators=[]
     )
 
     # Footer display configuration
-    enable_footer = BooleanField(_("Mostrar pie de página en páginas públicas"), default=True, validators=[])
+    enable_footer = BooleanField(_l("Mostrar pie de página en páginas públicas"), default=True, validators=[])
 
     # Social media links
-    social_facebook = StringField(_("URL de Facebook"), validators=[])
-    social_twitter = StringField(_("URL de Twitter/X"), validators=[])
-    social_linkedin = StringField(_("URL de LinkedIn"), validators=[])
-    social_youtube = StringField(_("URL de YouTube"), validators=[])
-    social_instagram = StringField(_("URL de Instagram"), validators=[])
-    social_github = StringField(_("URL de GitHub"), validators=[])
+    social_facebook = StringField(_l("URL de Facebook"), validators=[])
+    social_twitter = StringField(_l("URL de Twitter/X"), validators=[])
+    social_linkedin = StringField(_l("URL de LinkedIn"), validators=[])
+    social_youtube = StringField(_l("URL de YouTube"), validators=[])
+    social_instagram = StringField(_l("URL de Instagram"), validators=[])
+    social_github = StringField(_l("URL de GitHub"), validators=[])
 
     # Contact information
-    contact_address = StringField(_("Dirección del negocio"), validators=[])
-    contact_email = StringField(_("Correo de contacto"), validators=[])
-    contact_phone = StringField(_("Teléfono"), validators=[])
-    contact_mobile = StringField(_("Número celular"), validators=[])
-    contact_whatsapp = StringField(_("WhatsApp"), validators=[])
+    contact_address = StringField(_l("Dirección del negocio"), validators=[])
+    contact_email = StringField(_l("Correo de contacto"), validators=[])
+    contact_phone = StringField(_l("Teléfono"), validators=[])
+    contact_mobile = StringField(_l("Número celular"), validators=[])
+    contact_whatsapp = StringField(_l("WhatsApp"), validators=[])
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -431,7 +435,7 @@ class ThemeForm(FlaskForm):
     """Formulario para editar el tema del sistema."""
 
     style = SelectField(
-        _("Estilo"),
+        _l("Estilo"),
         choices=[],
     )
 
@@ -472,7 +476,7 @@ class BaseForm(FlaskForm):
 
     nombre = StringField(validators=[DataRequired()])
     descripcion = MdeField(validators=[DataRequired()])
-    descripcion_html_preformateado = BooleanField(_("Descripción en HTML preformateado"), default=False, validators=[])
+    descripcion_html_preformateado = BooleanField(_l("Descripción en HTML preformateado"), default=False, validators=[])
 
 
 class GrupoForm(BaseForm):
@@ -486,14 +490,14 @@ class CurseForm(BaseForm):
     # Nombre y descripción de la base.
     codigo = StringField(validators=[DataRequired()])
     descripcion_corta = StringField(validators=[DataRequired()])
-    nivel = SelectField(_("Nivel"), choices=[], coerce=int, validators=[])
+    nivel = SelectField(_l("Nivel"), choices=[], coerce=int, validators=[])
     duracion = FlexibleIntegerField(validators=[])
     # Estado de publicación
     publico = BooleanField(validators=[])
     # Modalidad
-    modalidad = SelectField(_("Modalidad"), choices=[], validators=[])
+    modalidad = SelectField(_l("Modalidad"), choices=[], validators=[])
     # Configuración del foro
-    foro_habilitado = BooleanField(_("Habilitar foro"), validators=[])
+    foro_habilitado = BooleanField(_l("Habilitar foro"), validators=[])
     # Disponibilidad de cupos
     limitado = BooleanField(validators=[])
     capacidad = FlexibleIntegerField(validators=[])
@@ -507,18 +511,18 @@ class CurseForm(BaseForm):
     auditable = BooleanField(validators=[])
     certificado = BooleanField(validators=[])
     plantilla_certificado = SelectField(
-        _("Plantilla de certificado"),
+        _l("Plantilla de certificado"),
         choices=[],
         validate_choice=False,
     )
     precio = FlexibleDecimalField(validators=[])
     categoria = SelectField(
-        _("Categoría"),
+        _l("Categoría"),
         choices=[],
         validate_choice=False,
     )
     etiquetas = SelectMultipleField(
-        _("Etiquetas"),
+        _l("Etiquetas"),
         choices=[],
         validate_choice=False,
     )
@@ -542,7 +546,7 @@ class CursoSeccionForm(BaseForm):
 class CursoRecursoForm(BaseForm):
     """Base para los recursos del curso."""
 
-    requerido = SelectField(_("Requerido"), choices=[], validators=[])
+    requerido = SelectField(_l("Requerido"), choices=[], validators=[])
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -576,15 +580,15 @@ class CursoLibraryFileForm(BaseForm):
     """Formulario para subir archivos a la biblioteca del curso."""
 
     nombre = StringField(
-        _("Nombre del archivo"),
+        _l("Nombre del archivo"),
         validators=[DataRequired(), Length(min=1, max=255)],
-        render_kw={"placeholder": _("Nombre descriptivo para el archivo")},
+        render_kw={"placeholder": _l("Nombre descriptivo para el archivo")},
     )
 
     descripcion = TextAreaField(
-        _("Descripción"),
+        _l("Descripción"),
         validators=[DataRequired(), Length(min=1, max=1000)],
-        render_kw={"placeholder": _("Describe el uso o contenido del archivo"), "rows": 3},
+        render_kw={"placeholder": _l("Describe el uso o contenido del archivo"), "rows": 3},
     )
 
 
@@ -609,7 +613,7 @@ class CursoRecursoExternalLink(CursoRecursoForm):
 class CursoRecursoSlides(CursoRecursoForm):
     """Formulario para insertar un SlideShow."""
 
-    notes = SelectField(_("Tema"), choices=[], validators=[])
+    notes = SelectField(_l("Tema"), choices=[], validators=[])
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -621,7 +625,7 @@ class SlideShowForm(BaseForm):
     """Formulario para crear una nueva presentación de diapositivas."""
 
     theme = SelectField(
-        _("Tema Reveal.js"),
+        _l("Tema Reveal.js"),
         choices=[],
         default="simple",
         validators=[DataRequired()],
@@ -636,9 +640,9 @@ class SlideShowForm(BaseForm):
 class SlideForm(FlaskForm):
     """Formulario para crear/editar una diapositiva individual."""
 
-    title = StringField(_("Título de la Diapositiva"), validators=[DataRequired()])
-    content = MdeField(_("Contenido de la Diapositiva"), validators=[DataRequired()])
-    order = IntegerField(_("Orden"), validators=[DataRequired()], default=1)
+    title = StringField(_l("Título de la Diapositiva"), validators=[DataRequired()])
+    content = MdeField(_l("Contenido de la Diapositiva"), validators=[DataRequired()])
+    order = IntegerField(_l("Orden"), validators=[DataRequired()], default=1)
 
 
 class SlideShowEditForm(SlideShowForm):
@@ -654,7 +658,7 @@ class CursoRecursoMeet(CursoRecursoForm):
     hora_inicio = TimeField(validators=[])
     hora_fin = TimeField(validators=[])
     url = StringField(validators=[DataRequired()])
-    notes = SelectField(_("Plataforma"), choices=[], validate_choice=False)
+    notes = SelectField(_l("Plataforma"), choices=[], validate_choice=False)
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -678,22 +682,22 @@ class ProgramaForm(BaseForm):
     codigo = StringField(validators=[DataRequired()])
     precio = FlexibleDecimalField(validators=[])
     publico = BooleanField(validators=[])
-    estado = SelectField(_("Estado"), choices=[], validate_choice=False)
+    estado = SelectField(_l("Estado"), choices=[], validate_choice=False)
     promocionado = BooleanField(validators=[])
     pagado = BooleanField(validators=[])
     certificado = BooleanField(validators=[])
     plantilla_certificado = SelectField(
-        _("Plantilla de certificado"),
+        _l("Plantilla de certificado"),
         choices=[],
         validate_choice=False,
     )
     categoria = SelectField(
-        _("Categoría"),
+        _l("Categoría"),
         choices=[],
         validate_choice=False,
     )
     etiquetas = SelectMultipleField(
-        _("Etiquetas"),
+        _l("Etiquetas"),
         choices=[],
         validate_choice=False,
     )
@@ -711,7 +715,7 @@ class RecursoForm(BaseForm):
     precio = DecimalField()
     publico = BooleanField(validators=[])
     promocionado = BooleanField(validators=[])
-    tipo = SelectField(_("Tipo"), choices=[], validators=[])
+    tipo = SelectField(_l("Tipo"), choices=[], validators=[])
     pagado = BooleanField(validators=[])
 
     def __init__(self, *args, **kwargs):
@@ -732,8 +736,8 @@ class UserForm(FlaskForm):
     twitter = StringField(validators=[])
     github = StringField(validators=[])
     youtube = StringField(validators=[])
-    genero = SelectField(_("Genero"), choices=[], validators=[])
-    titulo = SelectField(_("Titulo"), choices=[], validators=[])
+    genero = SelectField(_l("Genero"), choices=[], validators=[])
+    titulo = SelectField(_l("Titulo"), choices=[], validators=[])
     nacimiento = DateField()
     bio = TextAreaField()
 
@@ -755,22 +759,22 @@ class MsgForm(FlaskForm):
 class MessageThreadForm(FlaskForm):
     """Form for creating a new message thread."""
 
-    subject = StringField(_("Asunto"), validators=[DataRequired()])
-    content = MdeField(_("Mensaje"), validators=[DataRequired()])
+    subject = StringField(_l("Asunto"), validators=[DataRequired()])
+    content = MdeField(_l("Mensaje"), validators=[DataRequired()])
     course_id = HiddenField(validators=[DataRequired()])
 
 
 class MessageReplyForm(FlaskForm):
     """Form for replying to a message thread."""
 
-    content = MdeField(_("Respuesta"), validators=[DataRequired()])
+    content = MdeField(_l("Respuesta"), validators=[DataRequired()])
     thread_id = HiddenField(validators=[DataRequired()])
 
 
 class MessageReportForm(FlaskForm):
     """Form for reporting a message or thread."""
 
-    reason = TextAreaField(_("Motivo del reporte"), validators=[DataRequired()])
+    reason = TextAreaField(_l("Motivo del reporte"), validators=[DataRequired()])
     message_id = HiddenField(validators=[])
     thread_id = HiddenField(validators=[])
 
@@ -801,7 +805,7 @@ class CertificateForm(FlaskForm):
     publico = BooleanField(validators=[])
     html = TextAreaField(widget=TextAreaNoEscape())
     css = TextAreaField(widget=TextAreaNoEscape())
-    tipo = SelectField(_("Tipo"), choices=[], validators=[])
+    tipo = SelectField(_l("Tipo"), choices=[], validators=[])
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -843,11 +847,11 @@ class PayaplForm(FlaskForm):
 class EmitCertificateForm(FlaskForm):
     """Form for emitting certificates."""
 
-    usuario = SelectField(_("Usuario"), choices=[], validators=[])
-    content_type = SelectField(_("Tipo de Contenido"), choices=[], validators=[])
-    curso = SelectField(_("Curso"), choices=[], validators=[])
-    master_class = SelectField(_("Clase Magistral"), choices=[], validators=[])
-    template = SelectField(_("Plantilla"), choices=[], validators=[])
+    usuario = SelectField(_l("Usuario"), choices=[], validators=[])
+    content_type = SelectField(_l("Tipo de Contenido"), choices=[], validators=[])
+    curso = SelectField(_l("Curso"), choices=[], validators=[])
+    master_class = SelectField(_l("Clase Magistral"), choices=[], validators=[])
+    template = SelectField(_l("Plantilla"), choices=[], validators=[])
     nota = DecimalField(validators=[])
 
     def __init__(self, *args, **kwargs):
@@ -865,22 +869,22 @@ class CheckMailForm(FlaskForm):
 class ChangePasswordForm(FlaskForm):
     """Formulario para cambiar la contraseña del usuario."""
 
-    current_password = PasswordField(_("Contraseña Actual"), validators=[DataRequired()])
-    new_password = PasswordField(_("Nueva Contraseña"), validators=[DataRequired()])
-    confirm_password = PasswordField(_("Confirmar Nueva Contraseña"), validators=[DataRequired()])
+    current_password = PasswordField(_l("Contraseña Actual"), validators=[DataRequired()])
+    new_password = PasswordField(_l("Nueva Contraseña"), validators=[DataRequired()])
+    confirm_password = PasswordField(_l("Confirmar Nueva Contraseña"), validators=[DataRequired()])
 
 
 class ForgotPasswordForm(FlaskForm):
     """Formulario para solicitar recuperación de contraseña."""
 
-    email = StringField(_("Correo Electrónico"), validators=[DataRequired()])
+    email = StringField(_l("Correo Electrónico"), validators=[DataRequired()])
 
 
 class ResetPasswordForm(FlaskForm):
     """Formulario para restablecer contraseña con token."""
 
-    new_password = PasswordField(_("Nueva Contraseña"), validators=[DataRequired()])
-    confirm_password = PasswordField(_("Confirmar Nueva Contraseña"), validators=[DataRequired()])
+    new_password = PasswordField(_l("Nueva Contraseña"), validators=[DataRequired()])
+    confirm_password = PasswordField(_l("Confirmar Nueva Contraseña"), validators=[DataRequired()])
 
 
 class PagoForm(FlaskForm):
@@ -905,18 +909,18 @@ class EvaluationForm(FlaskForm):
     """Formulario para crear/editar una evaluación."""
 
     title = StringField(LABEL_TITULO, validators=[DataRequired()])
-    description = TextAreaField(_("Descripción"))
-    is_exam = BooleanField(_("Es un examen"))
-    passing_score = DecimalField(_("Puntuación mínima para aprobar"), default=70.0, validators=[DataRequired()])
-    max_attempts = IntegerField(_("Máximo número de intentos (vacío = ilimitado)"))
+    description = TextAreaField(_l("Descripción"))
+    is_exam = BooleanField(_l("Es un examen"))
+    passing_score = DecimalField(_l("Puntuación mínima para aprobar"), default=70.0, validators=[DataRequired()])
+    max_attempts = IntegerField(_l("Máximo número de intentos (vacío = ilimitado)"))
 
 
 class QuestionForm(FlaskForm):
     """Formulario para crear/editar una pregunta."""
 
-    text = TextAreaField(_("Texto de la pregunta"), validators=[DataRequired()])
-    type = SelectField(_("Tipo"), choices=[], validators=[DataRequired()])
-    explanation = TextAreaField(_("Explicación (opcional)"))
+    text = TextAreaField(_l("Texto de la pregunta"), validators=[DataRequired()])
+    type = SelectField(_l("Tipo"), choices=[], validators=[DataRequired()])
+    explanation = TextAreaField(_l("Explicación (opcional)"))
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -927,14 +931,14 @@ class QuestionForm(FlaskForm):
 class QuestionOptionForm(FlaskForm):
     """Formulario para crear/editar una opción de pregunta."""
 
-    text = StringField(_("Texto de la opción"), validators=[DataRequired()])
-    is_correct = BooleanField(_("Es correcta"))
+    text = StringField(_l("Texto de la opción"), validators=[DataRequired()])
+    is_correct = BooleanField(_l("Es correcta"))
 
 
 class EvaluationReopenRequestForm(FlaskForm):
     """Formulario para solicitar reabrir una evaluación."""
 
-    justification_text = TextAreaField(_("Justificación"), validators=[DataRequired()], render_kw={"rows": 4})
+    justification_text = TextAreaField(_l("Justificación"), validators=[DataRequired()], render_kw={"rows": 4})
 
 
 class TakeEvaluationForm(FlaskForm):
@@ -949,42 +953,42 @@ class TakeEvaluationForm(FlaskForm):
 class ForoMensajeForm(FlaskForm):
     """Formulario para crear un nuevo mensaje del foro."""
 
-    contenido = MdeField(_("Mensaje"), validators=[DataRequired()])
+    contenido = MdeField(_l("Mensaje"), validators=[DataRequired()])
     parent_id = HiddenField()
 
 
 class ForoMensajeRespuestaForm(FlaskForm):
     """Formulario para responder a un mensaje del foro."""
 
-    contenido = MdeField(_("Respuesta"), validators=[DataRequired()])
+    contenido = MdeField(_l("Respuesta"), validators=[DataRequired()])
 
 
 class AnnouncementBaseForm(FlaskForm):
     """Formulario base para crear/editar anuncios sin campos de BaseForm."""
 
     title = StringField(LABEL_TITULO, validators=[DataRequired()])
-    message = MdeField(_("Mensaje"), validators=[DataRequired()])
-    expires_at = DateField(_("Fecha de expiración"), validators=[], render_kw={"placeholder": _("Opcional")})
+    message = MdeField(_l("Mensaje"), validators=[DataRequired()])
+    expires_at = DateField(_l("Fecha de expiración"), validators=[], render_kw={"placeholder": _l("Opcional")})
 
 
 class AnnouncementForm(BaseForm):
     """Formulario para anuncios que requiere campos de BaseForm."""
 
     title = StringField(LABEL_TITULO, validators=[DataRequired()])
-    message = MdeField(_("Mensaje"), validators=[DataRequired()])
-    expires_at = DateField(_("Fecha de expiración"), validators=[], render_kw={"placeholder": _("Opcional")})
+    message = MdeField(_l("Mensaje"), validators=[DataRequired()])
+    expires_at = DateField(_l("Fecha de expiración"), validators=[], render_kw={"placeholder": _l("Opcional")})
 
 
 class GlobalAnnouncementForm(AnnouncementForm):
     """Formulario para anuncios globales (solo administradores)."""
 
-    is_sticky = BooleanField(_("Anuncio destacado"))
+    is_sticky = BooleanField(_l("Anuncio destacado"))
 
 
 class CourseAnnouncementForm(AnnouncementBaseForm):
     """Formulario para anuncios de curso (instructores)."""
 
-    course_id = SelectField(_("Curso"), coerce=str, validators=[DataRequired()])
+    course_id = SelectField(_l("Curso"), coerce=str, validators=[DataRequired()])
 
 
 # ---------------------------------------------------------------------------------------
@@ -995,23 +999,23 @@ class CourseAnnouncementForm(AnnouncementBaseForm):
 class CouponForm(FlaskForm):
     """Formulario para crear y editar cupones de descuento."""
 
-    code = StringField(_("Código del Cupón"), validators=[DataRequired()], render_kw={"placeholder": _("Ej: DESCUENTO50")})
+    code = StringField(_l("Código del Cupón"), validators=[DataRequired()], render_kw={"placeholder": _l("Ej: DESCUENTO50")})
     discount_type = SelectField(
-        _("Tipo de Descuento"),
+        _l("Tipo de Descuento"),
         choices=[],
         default="percentage",
         validators=[DataRequired()],
     )
-    discount_value = DecimalField(_("Valor del Descuento"), validators=[DataRequired()], render_kw={"min": "0"})
+    discount_value = DecimalField(_l("Valor del Descuento"), validators=[DataRequired()], render_kw={"min": "0"})
     max_uses = FlexibleIntegerField(
-        _("Máximo de Usos"),
+        _l("Máximo de Usos"),
         validators=[Optional()],
-        render_kw={"min": "1", "placeholder": _("Dejar vacío para ilimitado")},
+        render_kw={"min": "1", "placeholder": _l("Dejar vacío para ilimitado")},
     )
     expires_at = MultiFormatDateField(
-        _("Fecha de Expiración"),
+        _l("Fecha de Expiración"),
         validators=[Optional()],
-        render_kw={"placeholder": _("Dejar vacío si no expira")},
+        render_kw={"placeholder": _l("Dejar vacío si no expira")},
     )
 
     def __init__(self, *args, **kwargs):
@@ -1023,7 +1027,7 @@ class CouponForm(FlaskForm):
 class CouponApplicationForm(FlaskForm):
     """Formulario para aplicar un cupón durante la inscripción."""
 
-    coupon_code = StringField(_("Código de Cupón"), render_kw={"placeholder": _("Código de cupón (opcional)")})
+    coupon_code = StringField(_l("Código de Cupón"), render_kw={"placeholder": _l("Código de cupón (opcional)")})
 
 
 # Blog forms
@@ -1031,11 +1035,11 @@ class BlogPostForm(BaseForm):
     """Formulario para crear/editar entradas de blog."""
 
     title = StringField(LABEL_TITULO, validators=[DataRequired()])
-    content = MdeField(_("Contenido"), validators=[DataRequired()])
-    allow_comments = BooleanField(_("Permitir comentarios"), default=True)
-    tags = StringField(_("Etiquetas (separadas por comas)"))
-    status = SelectField(_("Estado"), choices=[], validators=[])
-    cover_image = FileField(_("Imagen de portada"), validators=[FileAllowed(["jpg", "png", "webp"], _("Solo imágenes"))])
+    content = MdeField(_l("Contenido"), validators=[DataRequired()])
+    allow_comments = BooleanField(_l("Permitir comentarios"), default=True)
+    tags = StringField(_l("Etiquetas (separadas por comas)"))
+    status = SelectField(_l("Estado"), choices=[], validators=[])
+    cover_image = FileField(_l("Imagen de portada"), validators=[FileAllowed(["jpg", "png", "webp"], _l("Solo imágenes"))])
 
     def __init__(self, *args, **kwargs):
         """Initialize form with translated choices."""
@@ -1046,13 +1050,13 @@ class BlogPostForm(BaseForm):
 class BlogTagForm(BaseForm):
     """Formulario para crear etiquetas de blog."""
 
-    name = StringField(_("Nombre"), validators=[DataRequired()])
+    name = StringField(_l("Nombre"), validators=[DataRequired()])
 
 
 class BlogCommentForm(BaseForm):
     """Formulario para comentarios de blog."""
 
-    content = TextAreaField(_("Comentario"), validators=[DataRequired()])
+    content = TextAreaField(_l("Comentario"), validators=[DataRequired()])
 
 
 # ---------------------------------------------------------------------------------------
@@ -1064,17 +1068,17 @@ class AdminCourseEnrollmentForm(FlaskForm):
     """Formulario para inscripción administrativa de estudiantes a cursos."""
 
     student_username = StringField(
-        _("Usuario del Estudiante"),
+        _l("Usuario del Estudiante"),
         validators=[DataRequired()],
-        render_kw={"placeholder": _("Nombre de usuario del estudiante")},
+        render_kw={"placeholder": _l("Nombre de usuario del estudiante")},
     )
     bypass_payment = BooleanField(
-        _("Omitir Pago"),
+        _l("Omitir Pago"),
         default=True,
-        render_kw={"title": _("Si está marcado, el estudiante tendrá acceso completo sin importar si el curso es pagado")},
+        render_kw={"title": _l("Si está marcado, el estudiante tendrá acceso completo sin importar si el curso es pagado")},
     )
     notes = TextAreaField(
-        _("Notas (opcional)"), render_kw={"rows": 3, "placeholder": _("Notas adicionales sobre la inscripción")}
+        _l("Notas (opcional)"), render_kw={"rows": 3, "placeholder": _l("Notas adicionales sobre la inscripción")}
     )
 
 
@@ -1082,50 +1086,50 @@ class AdminProgramEnrollmentForm(FlaskForm):
     """Formulario para inscripción administrativa de estudiantes a programas."""
 
     student_username = StringField(
-        _("Usuario del Estudiante"),
+        _l("Usuario del Estudiante"),
         validators=[DataRequired()],
-        render_kw={"placeholder": _("Nombre de usuario del estudiante")},
+        render_kw={"placeholder": _l("Nombre de usuario del estudiante")},
     )
     bypass_payment = BooleanField(
-        _("Omitir Pago"),
+        _l("Omitir Pago"),
         default=True,
         render_kw={
-            "title": _("Si está marcado, el estudiante tendrá acceso completo a todos los cursos sin importar si son pagados")
+            "title": _l("Si está marcado, el estudiante tendrá acceso completo a todos los cursos sin importar si son pagados")
         },
     )
     notes = TextAreaField(
-        _("Notas (opcional)"), render_kw={"rows": 3, "placeholder": _("Notas adicionales sobre la inscripción")}
+        _l("Notas (opcional)"), render_kw={"rows": 3, "placeholder": _l("Notas adicionales sobre la inscripción")}
     )
 
 
 class EnlaceUtilForm(FlaskForm):
     """Formulario para crear/editar enlaces útiles en el footer."""
 
-    titulo = StringField(_("Título del enlace"), validators=[DataRequired(), Length(min=1, max=100)])
-    url = StringField(_("URL"), validators=[DataRequired(), Length(min=1, max=500)])
-    orden = IntegerField(_("Orden"), default=0, validators=[])
-    activo = BooleanField(_("Activo"), default=True, validators=[])
+    titulo = StringField(_l("Título del enlace"), validators=[DataRequired(), Length(min=1, max=100)])
+    url = StringField(_l("URL"), validators=[DataRequired(), Length(min=1, max=500)])
+    orden = IntegerField(_l("Orden"), default=0, validators=[])
+    activo = BooleanField(_l("Activo"), default=True, validators=[])
 
 
 class CustomPageFooterForm(FlaskForm):
     """Formulario para configurar si una página custom se muestra en el footer."""
 
-    mostrar_en_footer = BooleanField(_("Mostrar en el footer"), default=False, validators=[])
+    mostrar_en_footer = BooleanField(_l("Mostrar en el footer"), default=False, validators=[])
 
 
 class CustomPageForm(FlaskForm):
     """Formulario para crear/editar páginas custom."""
 
-    title = StringField(_("Título"), validators=[DataRequired(), Length(min=1, max=200)])
-    slug = StringField(_("Slug (URL)"), validators=[DataRequired(), Length(min=1, max=50)])
-    content = TextAreaField(_("Contenido (HTML)"), validators=[DataRequired()])
-    is_active = BooleanField(_("Activa (visible públicamente)"), default=True, validators=[])
-    mostrar_en_footer = BooleanField(_("Mostrar en el footer del sitio"), default=False, validators=[])
+    title = StringField(_l("Título"), validators=[DataRequired(), Length(min=1, max=200)])
+    slug = StringField(_l("Slug (URL)"), validators=[DataRequired(), Length(min=1, max=50)])
+    content = TextAreaField(_l("Contenido (HTML)"), validators=[DataRequired()])
+    is_active = BooleanField(_l("Activa (visible públicamente)"), default=True, validators=[])
+    mostrar_en_footer = BooleanField(_l("Mostrar en el footer del sitio"), default=False, validators=[])
 
 
 class ExternalApiKeyForm(FlaskForm):
     """Form to create a new external API key."""
 
-    name = StringField(_("Nombre de la integración"), validators=[DataRequired(), Length(max=100)])
-    allowed_origin = StringField(_("Origen permitido (opcional)"), validators=[Optional(), Length(max=255)])
-    notes = TextAreaField(_("Notas"), validators=[Optional()])
+    name = StringField(_l("Nombre de la integración"), validators=[DataRequired(), Length(max=100)])
+    allowed_origin = StringField(_l("Origen permitido (opcional)"), validators=[Optional(), Length(max=255)])
+    notes = TextAreaField(_l("Notas"), validators=[Optional()])

--- a/tests/test_form_labels_are_lazy.py
+++ b/tests/test_form_labels_are_lazy.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Form labels must be lazily translated.
+
+``now_lms/i18n.py`` documents the rule:
+
+    # Para traducciones perezosas (formularios):
+    # from now_lms.i18n import _l
+    # field = StringField(_l('Etiqueta del campo'))
+
+A class-body ``_()`` call is evaluated when the module is imported — before any
+request exists — so the label freezes to whichever locale happened to be active
+at import time and never changes again. ``_l()`` defers resolution to render
+time, which is what makes a form translate per request.
+
+This test walks every WTForms class in ``now_lms.forms`` and asserts the labels
+are lazy, so the convention cannot silently regress.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from flask_babel import LazyString
+from flask_wtf import FlaskForm
+
+import now_lms.forms as forms_module
+
+
+# A label supplied positionally to a Field becomes field.kwargs["label"] on the
+# UnboundField; WTForms falls back to a prettified attribute name when no label
+# was given, and those are plain strings we must not flag.
+def _explicit_labels():
+    """Yield (form_name, field_name, label) for every explicitly-labelled field."""
+    for form_name, form_class in vars(forms_module).items():
+        if not (inspect.isclass(form_class) and issubclass(form_class, FlaskForm) and form_class is not FlaskForm):
+            continue
+        if form_class.__module__ != forms_module.__name__:
+            continue
+        for field_name in dir(form_class):
+            unbound = getattr(form_class, field_name, None)
+            if not hasattr(unbound, "field_class"):
+                continue
+            label = unbound.kwargs.get("label")
+            if label is None and unbound.args:
+                label = unbound.args[0]
+            if label is None:
+                continue
+            yield form_name, field_name, label
+
+
+def test_at_least_one_labelled_field_is_discovered():
+    """Guard the walker itself — a silent zero would make this test vacuous."""
+    assert len(list(_explicit_labels())) > 50
+
+
+def test_every_form_label_is_lazily_translated():
+    """No class-body label may be an eagerly-translated plain string."""
+    eager = [
+        f"{form_name}.{field_name} = {label!r}"
+        for form_name, field_name, label in _explicit_labels()
+        if isinstance(label, str) and not isinstance(label, LazyString)
+    ]
+    assert not eager, "these labels are evaluated at import time; use _l() instead of _():\n  " + "\n  ".join(eager)

--- a/tests/test_translation_extraction.py
+++ b/tests/test_translation_extraction.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Every translatable string must actually be extractable.
+
+``_l`` (``lazy_gettext``) is not one of Babel's default keywords, so an
+extraction run without ``-k _l`` silently skips every lazily-translated form
+label — they render in the source language forever, with no msgid for a
+translator to fill in. This test runs the real extraction and asserts the
+lazily-labelled strings come out.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LANG_SCRIPT = REPO_ROOT / "dev" / "lang.sh"
+
+
+def _extract(tmp_path: Path, *extra_args: str) -> str:
+    pot = tmp_path / "messages.pot"
+    result = subprocess.run(
+        [sys.executable, "-m", "babel.messages.frontend", "extract", "-F", "babel.cfg", *extra_args, "-o", str(pot), "."],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if result.returncode != 0:  # pragma: no cover - surfaced only on a broken toolchain
+        pytest.skip(f"pybabel extract unavailable: {result.stderr[-300:]}")
+    return pot.read_text(encoding="utf-8")
+
+
+@pytest.mark.slow
+def test_lazy_labels_are_extractable(tmp_path):
+    """A label that exists only as _l() must appear in the extracted catalogue."""
+    catalogue = _extract(tmp_path, "-k", "_l")
+    # "URL de Facebook" is a ConfigForm label and appears nowhere else in the
+    # source, so it is a clean probe for _l extraction.
+    assert 'msgid "URL de Facebook"' in catalogue
+
+
+def test_lang_script_passes_the_lazy_keyword():
+    """dev/lang.sh must keep -k _l, or lazy labels silently stop being extracted."""
+    script = LANG_SCRIPT.read_text(encoding="utf-8")
+    extract_line = next(line for line in script.splitlines() if line.startswith("pybabel extract"))
+    assert re.search(r"-k\s+_l\b", extract_line), (
+        "dev/lang.sh must pass -k _l to pybabel extract; without it every _l() form label is skipped"
+    )

--- a/tests/test_translation_extraction.py
+++ b/tests/test_translation_extraction.py
@@ -53,3 +53,46 @@ def test_lang_script_passes_the_lazy_keyword():
     assert re.search(r"-k\s+_l\b", extract_line), (
         "dev/lang.sh must pass -k _l to pybabel extract; without it every _l() form label is skipped"
     )
+
+
+def test_lang_script_passes_the_plural_keyword():
+    """Same for -k _n:1,2, so the documented plural helper is extractable."""
+    script = LANG_SCRIPT.read_text(encoding="utf-8")
+    extract_line = next(line for line in script.splitlines() if line.startswith("pybabel extract"))
+    assert re.search(r"-k\s+_n:1,2\b", extract_line), (
+        "dev/lang.sh must pass -k _n:1,2 to pybabel extract; without it every _n() plural is skipped"
+    )
+
+
+@pytest.mark.slow
+def test_plural_helper_is_extractable_with_the_declared_keyword(tmp_path):
+    """Prove the keyword spec works, without adding an unused _n() call to the app.
+
+    Extracts from a throwaway module that calls _n(), first with Babel's defaults
+    and then with the spec dev/lang.sh now declares.
+    """
+    probe_dir = tmp_path / "probe"
+    probe_dir.mkdir()
+    (probe_dir / "probe.py").write_text(
+        "from now_lms.i18n import _n\n\n\ndef describe(count):\n"
+        '    return _n("%(num)d archivo pendiente", "%(num)d archivos pendientes", count, num=count)\n',
+        encoding="utf-8",
+    )
+    (probe_dir / "babel.cfg").write_text("[python: **.py]\n", encoding="utf-8")
+
+    def extract(*extra: str) -> str:
+        pot = tmp_path / f"probe{len(extra)}.pot"
+        result = subprocess.run(
+            [sys.executable, "-m", "babel.messages.frontend", "extract", "-F", "babel.cfg", *extra, "-o", str(pot), "."],
+            cwd=probe_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:  # pragma: no cover - broken toolchain only
+            pytest.skip(f"pybabel extract unavailable: {result.stderr[-300:]}")
+        return pot.read_text(encoding="utf-8")
+
+    assert 'msgid "%(num)d archivo pendiente"' not in extract(), "expected Babel defaults to miss _n()"
+    assert 'msgid "%(num)d archivo pendiente"' in extract("-k", "_n:1,2"), "-k _n:1,2 should pick up the singular"
+    assert 'msgid_plural "%(num)d archivos pendientes"' in extract("-k", "_n:1,2"), "and the plural form"


### PR DESCRIPTION
## The bug

`now_lms/i18n.py` already documents the convention:

```
# Para traducciones perezosas (formularios):
# from now_lms.i18n import _l
# field = StringField(_l('Etiqueta del campo'))
```

But 129 class-body labels in `now_lms/forms/__init__.py` use `_()`:

```python
moneda = SelectField(_("Moneda"), choices=[], validators=[])
enable_blog = BooleanField(_("Habilitar Blog"), default=False, validators=[])
```

A class body runs **at import time** — before any request exists, so before a locale is known. `gettext()` therefore resolves once, to whatever locale happened to be active then, and the label keeps that language for the life of the process. The form renders one language regardless of the visitor's locale. `lazy_gettext()` defers resolution to render time, which is the whole point of the documented rule.

This also covers `LABEL_TITULO` (line 349) — a module-level constant reused as the label of six forms, eagerly evaluated for the same reason.

## The second bug this exposed

`_l` is **not** one of Babel's default keywords, and `dev/lang.sh` does not pass `-k _l`:

```sh
pybabel extract -F babel.cfg -o now_lms/translations/messages.pot .
```

So lazily-labelled strings are never extracted. Measured with your own command against `"URL de Facebook"` (a `ConfigForm` label that appears nowhere else in the source):

| Extraction command | `msgid "URL de Facebook"` |
|---|---|
| `pybabel extract -F babel.cfg -o … .` (current) | **0** |
| `pybabel extract -F babel.cfg -k _l -o … .` | 1 |

**This is pre-existing, not caused by this PR:** the 77 `_l()` calls already in the tree are equally absent from the catalogue today, so those labels cannot be translated by anyone. `dev/lang.sh` now passes `-k _l`, which fixes both the existing gap and the strings this PR converts.

I chose rewriting the calls over registering `_()` as a lazy alias in Babel config, because the fix has to change *when* the string resolves, not just how it is extracted.

## Tests

Both mutation-checked.

**`tests/test_form_labels_are_lazy.py`** — walks every `FlaskForm` subclass in the module and asserts no explicit label is a plain `str`, so the convention cannot regress silently. This is not decorative: it **caught six labels a mechanical pass had missed** (the `LABEL_TITULO` reuse). Reverting the source change turns it red.

**`tests/test_translation_extraction.py`** — runs a real extraction and asserts a lazily-labelled string appears in the output, and separately guards the `-k _l` flag in `dev/lang.sh`. Reverting `dev/lang.sh` turns it red.

```
$ pytest tests/test_form_labels_are_lazy.py tests/test_translation_extraction.py -q
....                                       [100%]
```

**Regression:** `tests/test_forms_comprehensive.py` passes 35/35. `ruff` + `flake8` clean; `pylint now_lms/forms/__init__.py` → **10.00/10**. Extraction with the updated command yields 2648 msgids.

## Scope

Label text is unchanged everywhere — every msgid is identical, so no existing translation is invalidated. Diff is `_(` → `_l(` inside field definitions, one constant, one line in `dev/lang.sh`, and two test files. Branched from `main` at v2.0.1 (`6baac92`).

**Related observation, deliberately not bundled:** `_n` (documented in `i18n.py` for plurals) is also not a Babel default keyword, so plural strings written as `_n(...)` are skipped by extraction too. Adding `-k _n:1,2` would fix that; happy to send it separately, or fold it in here if you prefer one change.

- Jeremy Longshore
intentsolutions.io
