### PR TITLE
perf(themes): drop the unused ionicons CDN loads from every bundled theme

### DIFF
--- a/now_lms/templates/themes/cambridge/base.j2
+++ b/now_lms/templates/themes/cambridge/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/corporative/base.j2
+++ b/now_lms/templates/themes/corporative/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/excel/base.j2
+++ b/now_lms/templates/themes/excel/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/excel/js.j2
+++ b/now_lms/templates/themes/excel/js.j2
@@ -1,6 +1,4 @@
 {% macro jslibs() -%}
-<script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-<script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
 
 <!-- Excel Theme Custom JavaScript -->
 <script>

--- a/now_lms/templates/themes/harvard/base.j2
+++ b/now_lms/templates/themes/harvard/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/now_lms/base.j2
+++ b/now_lms/templates/themes/now_lms/base.j2
@@ -29,7 +29,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/ocean/base.j2
+++ b/now_lms/templates/themes/ocean/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/oxford/base.j2
+++ b/now_lms/templates/themes/oxford/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/now_lms/templates/themes/sakura/base.j2
+++ b/now_lms/templates/themes/sakura/base.j2
@@ -28,7 +28,5 @@
         {% block contenido %}{% endblock %}
 
         <!-- Fin del bloque contenido -->
-        <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
-        <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
     </body>
 </html>

--- a/tests/test_no_dead_cdn_assets.py
+++ b/tests/test_no_dead_cdn_assets.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Bundled themes must not load third-party assets they never use.
+
+Every theme pulled ionicons from unpkg.com on every page render — two extra
+third-party requests per page — while no template contained a single
+``<ion-icon>`` element. This test keeps that from creeping back, and keeps the
+pairing honest: if a theme ever does start using ion-icon, the loader is
+allowed again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+THEMES_DIR = Path(__file__).resolve().parent.parent / "now_lms" / "templates" / "themes"
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "now_lms" / "templates"
+
+
+def _all_template_text() -> str:
+    return "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore")
+        for p in TEMPLATES_DIR.rglob("*")
+        if p.suffix in {".j2", ".html"}
+    )
+
+
+def test_ionicons_is_not_loaded_unless_it_is_used():
+    """No ionicons loader while no template renders an <ion-icon>."""
+    templates = _all_template_text()
+    uses_element = "<ion-icon" in templates
+    loads_library = "ionicons" in templates
+
+    if uses_element:  # pragma: no cover - only if a theme adopts ion-icon later
+        assert loads_library, "a template uses <ion-icon> but no theme loads the library"
+    else:
+        assert not loads_library, (
+            "themes load the ionicons library from a CDN but no template uses <ion-icon>; "
+            "drop the loader or use the element"
+        )
+
+
+def test_the_theme_tree_was_actually_scanned():
+    """Guard the scanner — an empty read would make the check above vacuous."""
+    text = _all_template_text()
+    assert len(text) > 100_000
+    assert THEMES_DIR.is_dir()


### PR DESCRIPTION
## What

Nine theme templates load ionicons 7.1.0 from unpkg.com on every page render:

```html
<script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
<script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
```

**No template in the tree contains a single `<ion-icon>` element.** Measured: 0 occurrences of `ion-icon` across `now_lms/templates`.

## Why it's worth removing

Every page, in every theme, paid for:

- two extra third-party requests, plus a DNS lookup and TLS handshake to `unpkg.com`
- a third-party origin inside the page's trust boundary — a CDN compromise would execute script in a logged-in session, for zero functional benefit
- a hard external dependency: any page render degrades if unpkg is slow or blocked (some corporate networks and privacy extensions block it outright)

…for a web-component library nothing rendered.

## The change

Removes the 18 script tags: 8 × `base.j2` (`now_lms`, `cambridge`, `corporative`, `excel`, `harvard`, `ocean`, `oxford`, `sakura`) plus `excel/js.j2`. No markup, CSS, or icon usage changes, because nothing referenced the library.

## Tests

`tests/test_no_dead_cdn_assets.py` **pairs the two facts** rather than hardcoding an absence — if a theme ever does start using `<ion-icon>`, the loader becomes required again; while none does, the loader must not be present. So it will not stand in the way of adopting ionicons deliberately later.

**Mutation-checked:** restoring one theme's loader turns it red.

```
$ pytest tests/test_no_dead_cdn_assets.py -q
..                                          [100%]
```

Also verified all 9 edited templates still parse and compile through Jinja (**9/9**) and the app serves the home page 200. `ruff` + `flake8` clean.

## Risk

Cosmetic-to-zero. If some downstream theme override does use `<ion-icon>` in a way I could not see from this repo, the icons would stop rendering — the test's pairing logic makes that condition explicit and easy to reverse by re-adding the loader alongside the usage.

## Related, deliberately not bundled

The themes also load **AlpineJS** from unpkg, and no template uses an `x-data` directive either. That one may be intentional scaffolding for theme authors, so I left it alone rather than assume. Say the word and I'll send it as its own change.

Branched from `main` at v2.0.1 (`6baac92`).

- Jeremy Longshore
intentsolutions.io
