### PR TITLE
fix(enroll): stop a repeat enrollment from adding a second enrollment row

### DIFF
--- a/now_lms/vistas/courses/enrollment.py
+++ b/now_lms/vistas/courses/enrollment.py
@@ -115,15 +115,31 @@ def _finalize_completed_enrollment(
         if applied_coupon and final_price == 0:
             applied_coupon.current_uses += 1
 
-        registro = EstudianteCurso(
-            curso=pago.curso,
-            usuario=pago.usuario,
-            vigente=True,
-            pago=pago.id,
+        # Reuse the student's existing enrollment if there is one, the same way
+        # paypal.py::_save_payment_enrollment does. Adding a second row for the
+        # same (usuario, curso) is never what we want — it just inflates the
+        # enrollment counts everything else reads.
+        registro = (
+            database.session.execute(
+                database.select(EstudianteCurso).filter_by(curso=pago.curso, usuario=pago.usuario)
+            )
+            .scalars()
+            .first()
         )
-        registro.creado = datetime.now(timezone.utc).date()
-        registro.creado_por = current_user.usuario
-        database.session.add(registro)
+        if registro is None:
+            registro = EstudianteCurso(
+                curso=pago.curso,
+                usuario=pago.usuario,
+                vigente=True,
+                pago=pago.id,
+            )
+            registro.creado = datetime.now(timezone.utc).date()
+            registro.creado_por = current_user.usuario
+            database.session.add(registro)
+        else:
+            registro.vigente = True
+            registro.pago = pago.id
+            registro.modificado_por = current_user.usuario
         database.session.commit()
         _crear_indice_avance_curso(course_code)
 
@@ -184,6 +200,18 @@ def _check_unverified_email_restriction(course_obj: Curso) -> bool:
     return False
 
 
+def _has_active_enrollment(course_code: str) -> bool:
+    """Whether the current user already holds a live enrollment in the course."""
+    return (
+        database.session.execute(
+            database.select(EstudianteCurso).filter_by(curso=course_code, usuario=current_user.usuario, vigente=True)
+        )
+        .scalars()
+        .first()
+        is not None
+    )
+
+
 def _process_validated_enrollment(
     form,
     course_obj: Curso,
@@ -192,6 +220,16 @@ def _process_validated_enrollment(
     course_code: str,
 ) -> Response:
     """Handle PagoForm submission when it has been successfully validated."""
+    # If they are already enrolled, there is nothing to do — send them to the
+    # course instead of writing another Pago and another enrollment row. Paid
+    # enrollments still go through, though: paying to upgrade an audit
+    # enrollment is a real flow, and paypal.py updates the existing row.
+    if _has_active_enrollment(course_code) and (
+        _is_free_enrollment(course_obj, pricing.final_price) or _is_audit_enrollment(mode, course_obj)
+    ):
+        flash(_("Ya está inscrito en este curso."), "info")
+        return redirect(url_for("course.tomar_curso", course_code=course_code))
+
     pago = _build_pago_from_form(form, course_obj, pricing.final_price)
 
     # Add coupon information to payment description

--- a/tests/test_duplicate_enrollment_guard.py
+++ b/tests/test_duplicate_enrollment_guard.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Enrolling twice should leave you with one enrollment, not two.
+
+The paid path already gets this right — ``paypal.py::_save_payment_enrollment``
+reuses the existing ``EstudianteCurso`` row. The free and audit paths did not,
+so submitting the enrollment form again just added another row for the same
+(usuario, curso) and quietly inflated every enrollment count that reads it.
+
+The one case that must keep working is upgrading: a student holding an audit
+enrollment is still allowed to pay.
+"""
+
+from now_lms.auth import proteger_passwd
+from now_lms.db import Curso, EstudianteCurso, Pago, Usuario, database
+
+PASSWORD = "dup-guard-pw-123"
+
+
+def _make_course(app, code, *, pagado, auditable=False):
+    with app.app_context():
+        database.session.add(
+            Curso(
+                nombre=f"Course {code}",
+                codigo=code,
+                descripcion="Duplicate-enrollment guard test course.",
+                descripcion_corta="Dup guard.",
+                estado="open",
+                publico=True,
+                pagado=pagado,
+                precio=100 if pagado else 0,
+                auditable=auditable,
+                certificado=False,
+                modalidad="self_paced",
+                creado_por="test",
+            )
+        )
+        database.session.commit()
+
+
+def _make_student(app, username):
+    with app.app_context():
+        database.session.add(
+            Usuario(
+                usuario=username,
+                acceso=proteger_passwd(PASSWORD),
+                nombre="Dup",
+                apellido="Guard",
+                correo_electronico=username,
+                tipo="student",
+                activo=True,
+                correo_electronico_verificado=True,
+                creado_por="test",
+            )
+        )
+        database.session.commit()
+
+
+def _login(client, username):
+    client.post("/user/login", data={"usuario": username, "acceso": PASSWORD})
+
+
+def _enrollment_rows(app, code, username):
+    with app.app_context():
+        return (
+            database.session.execute(database.select(EstudianteCurso).filter_by(curso=code, usuario=username))
+            .scalars()
+            .all()
+        )
+
+
+def _pago_rows(app, code, username):
+    with app.app_context():
+        return database.session.execute(database.select(Pago).filter_by(curso=code, usuario=username)).scalars().all()
+
+
+def _enroll(client, code, username, **extra):
+    """Submit the enrollment form.
+
+    The address fields are filled in because PagoForm currently requires them on
+    every course, free ones included. That is its own discussion; this test just
+    plays along so it can focus on the duplicate-row question.
+    """
+    data = {
+        "nombre": "Dup",
+        "apellido": "Guard",
+        "correo_electronico": username,
+        "direccion1": "1 Main St",
+        "direccion2": "",
+        "pais": "Nicaragua",
+        "provincia": "Managua",
+        "codigo_postal": "10001",
+    }
+    data.update(extra)
+    return client.post(f"/course/{code}/enroll", data=data, follow_redirects=False)
+
+
+def test_first_free_enrollment_creates_one_row(app, client):
+    user = "dup-first@example.test"
+    _make_course(app, "DUPONE", pagado=False)
+    _make_student(app, user)
+    _login(client, user)
+
+    _enroll(client, "DUPONE", user)
+    assert len(_enrollment_rows(app, "DUPONE", user)) == 1
+
+
+def test_second_free_enrollment_does_not_add_a_row(app, client):
+    """The regression itself: submit three times, end up with one enrollment."""
+    user = "dup-second@example.test"
+    _make_course(app, "DUPTWO", pagado=False)
+    _make_student(app, user)
+    _login(client, user)
+
+    for _ in range(3):
+        _enroll(client, "DUPTWO", user)
+
+    rows = _enrollment_rows(app, "DUPTWO", user)
+    assert len(rows) == 1, f"expected 1 enrollment after 3 submissions, found {len(rows)}"
+
+
+def test_second_free_enrollment_does_not_add_a_payment_row(app, client):
+    """Turning away a repeat enrollment should not leave a stray Pago behind."""
+    user = "dup-pago@example.test"
+    _make_course(app, "DUPPAGO", pagado=False)
+    _make_student(app, user)
+    _login(client, user)
+
+    _enroll(client, "DUPPAGO", user)
+    first = len(_pago_rows(app, "DUPPAGO", user))
+    _enroll(client, "DUPPAGO", user)
+    second = len(_pago_rows(app, "DUPPAGO", user))
+
+    assert second == first, f"re-enrollment created another Pago row ({first} -> {second})"
+
+
+def test_already_enrolled_student_is_sent_to_the_course(app, client):
+    user = "dup-redirect@example.test"
+    _make_course(app, "DUPREDIR", pagado=False)
+    _make_student(app, user)
+    _login(client, user)
+
+    _enroll(client, "DUPREDIR", user)
+    response = _enroll(client, "DUPREDIR", user)
+
+    assert response.status_code == 302
+    assert "/course/DUPREDIR/take" in response.headers["Location"]
+
+
+def test_audit_enrollment_may_still_upgrade_to_paid(app, client):
+    """The case worth protecting: auditing a course must not block paying for it."""
+    user = "dup-upgrade@example.test"
+    _make_course(app, "DUPUP", pagado=True, auditable=True)
+    _make_student(app, user)
+    _login(client, user)
+
+    # Audit first: free, and it creates the enrollment row.
+    _enroll(client, "DUPUP", user, modo="audit")
+    assert len(_enrollment_rows(app, "DUPUP", user)) == 1
+
+    # Now pay for it. This must reach the payment flow, not get waved off.
+    response = _enroll(client, "DUPUP", user)
+    assert response.status_code == 302
+    assert "/take" not in response.headers["Location"], (
+        "the paid upgrade was refused as a duplicate; it must reach the payment flow"
+    )
+    assert len(_enrollment_rows(app, "DUPUP", user)) == 1


### PR DESCRIPTION
## What's happening

Submit the enrollment form again for a course you're already in, and you get another `EstudianteCurso` row — plus another `Pago` — every time. Nothing errors, so the duplicates quietly accumulate and inflate every enrollment count and report that reads the table.

I watched a student do it three times on a free course while trying to get in: the page showed them an *Enroll* button, they clicked it, nothing visibly changed, they clicked again.

## The paid path already gets this right

`paypal.py::_save_payment_enrollment` looks for the existing enrollment and updates it:

```python
enrollment = database.session.execute(
    database.select(EstudianteCurso).filter_by(usuario=pago.usuario, curso=course_code)
).scalars().first()
if enrollment:
    enrollment.vigente = True
    enrollment.pago = pago.id
else:
    database.session.add(EstudianteCurso(...))
```

`enrollment.py` just inserts. This PR brings the free and audit paths in line with the pattern you already established:

- **`_finalize_completed_enrollment`** reuses an existing `(usuario, curso)` row instead of adding one.
- **`_process_validated_enrollment`** turns a repeat enrollment away early, so it no longer writes a throwaway `Pago` on the way, and redirects the student to the course they're already in.

## The case I was careful not to break

The early return **deliberately lets paid enrollments through** when a row already exists, because paying to upgrade an audit enrollment is a real flow — the enrollment page advertises it:

> *Puede pagar el valor del curso antes de finalizarlo y acceder a las evaluaciones y la certificación.*

A plain "already enrolled → refuse" would have killed that. And when that payment completes, `paypal.py` updates the existing row, so no duplicate appears there either. There's a test pinning this specifically.

I chose mirroring the paypal upsert over adding a unique constraint on `(usuario, curso)`, because a constraint needs a migration and would turn an impatient double-click into a 500 instead of a sensible redirect. A constraint would still be reasonable belt-and-braces later if you want one — happy to send it.

## Tests

`tests/test_duplicate_enrollment_guard.py`, five cases:

| Case | Expected |
|---|---|
| first enrollment | one row |
| **three submissions** | still one row ← the regression |
| turned-away re-enrollment | no stray `Pago` |
| already enrolled | redirected to the course |
| **audit → paid** | reaches the payment flow, still one row |

**Mutation-checked:** reverting the source change fails **2 of the 5** — including the three-submission regression — while the audit-upgrade case stays green, so it's guarding that path rather than just following the change.

```
$ pytest tests/test_duplicate_enrollment_guard.py -q
.....                                       [100%]
```

**Regression:** `tests/test_coupons.py` passes 11/11. `ruff` + `flake8` clean; `pylint` **10.00/10**.

Branched from `main` at v2.0.1 (`6baac92`). This is the follow-up I mentioned in #229.

- Jeremy Longshore
intentsolutions.io
