### PR TITLE
feat(db): enforce one enrollment per student and course

### DIFF
--- a/now_lms/db/__init__.py
+++ b/now_lms/db/__init__.py
@@ -603,6 +603,12 @@ class ModeradorCurso(database.Model, BaseTabla):
 class EstudianteCurso(database.Model, BaseTabla):
     """Uno o mas usuario de tipo user pueden estar a cargo de un curso."""
 
+    # A student is either enrolled in a course or not — a second row for the same
+    # pair has never meant anything, it just inflates the counts everything else
+    # reads. The enrollment paths upsert, and this keeps a bug or a double-submit
+    # from getting past them.
+    __table_args__ = (database.UniqueConstraint("usuario", "curso", name="uq_estudiante_curso_usuario_curso"),)
+
     curso = database.Column(
         database.String(20), database.ForeignKey(LLAVE_FORANEA_CURSO, ondelete="CASCADE"), nullable=False, index=True
     )

--- a/now_lms/migrations/20260730_000000_unique_enrollment_per_student_and_course.py
+++ b/now_lms/migrations/20260730_000000_unique_enrollment_per_student_and_course.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""Enforce one enrollment per (usuario, curso).
+
+A second EstudianteCurso row for the same student and course has never meant
+anything — it just inflates every enrollment count that reads the table. The
+enrollment paths upsert now, and this stops a bug or a double-submit from
+getting past them.
+
+Existing databases very likely already contain duplicates, so this migration
+cleans up before adding the constraint. For each duplicated pair it keeps one
+row, preferring (in order) a row that carries a payment, then an active one,
+then the oldest — and repoints anything referencing a discarded row at the
+keeper rather than orphaning it.
+
+Revision ID: 20260730_000000
+Revises: 20260726_000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260730_000000"
+down_revision = "20260726_000000"
+branch_labels = None
+depends_on = None
+
+CONSTRAINT_NAME = "uq_estudiante_curso_usuario_curso"
+
+
+def _duplicate_groups(bind) -> list[tuple[str, str]]:
+    """Return the (usuario, curso) pairs that have more than one enrollment row."""
+    rows = bind.execute(
+        sa.text(
+            "SELECT usuario, curso FROM estudiante_curso "
+            "GROUP BY usuario, curso HAVING COUNT(*) > 1"
+        )
+    ).fetchall()
+    return [(row[0], row[1]) for row in rows]
+
+
+def _rows_for(bind, usuario: str, curso: str) -> list[tuple[str, str | None, bool | None]]:
+    """Return (id, pago, vigente) for one pair, best keeper first.
+
+    Preference order: a row with a payment, then an active row, then the oldest.
+    Ordering happens in Python so the same rule applies on every backend —
+    boolean and NULL ordering differ between SQLite, PostgreSQL and MySQL.
+    """
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, pago, vigente FROM estudiante_curso "
+            "WHERE usuario = :usuario AND curso = :curso"
+        ),
+        {"usuario": usuario, "curso": curso},
+    ).fetchall()
+    return sorted(rows, key=lambda r: (r[1] is None, not bool(r[2]), r[0]))
+
+
+def _table_exists(inspector, name: str) -> bool:
+    return name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Collapse duplicate enrollments, then add the unique constraint."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _table_exists(inspector, "estudiante_curso"):
+        return
+
+    has_remote_requests = _table_exists(inspector, "remote_enrollment_requests")
+
+    for usuario, curso in _duplicate_groups(bind):
+        ordered = _rows_for(bind, usuario, curso)
+        keeper_id = ordered[0][0]
+        discarded = [row[0] for row in ordered[1:]]
+        if not discarded:
+            continue
+
+        if has_remote_requests:
+            # Do not orphan a request that points at a row we are about to drop.
+            for discarded_id in discarded:
+                bind.execute(
+                    sa.text(
+                        "UPDATE remote_enrollment_requests SET enrollment_id = :keeper "
+                        "WHERE enrollment_id = :discarded"
+                    ),
+                    {"keeper": keeper_id, "discarded": discarded_id},
+                )
+
+        for discarded_id in discarded:
+            bind.execute(
+                sa.text("DELETE FROM estudiante_curso WHERE id = :discarded"),
+                {"discarded": discarded_id},
+            )
+
+    existing = {uc.get("name") for uc in inspector.get_unique_constraints("estudiante_curso")}
+    if CONSTRAINT_NAME not in existing:
+        with op.batch_alter_table("estudiante_curso") as batch_op:
+            batch_op.create_unique_constraint(CONSTRAINT_NAME, ["usuario", "curso"])
+
+
+def downgrade() -> None:
+    """Drop the constraint. The collapsed duplicate rows are not restored."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _table_exists(inspector, "estudiante_curso"):
+        return
+
+    existing = {uc.get("name") for uc in inspector.get_unique_constraints("estudiante_curso")}
+    if CONSTRAINT_NAME in existing:
+        with op.batch_alter_table("estudiante_curso") as batch_op:
+            batch_op.drop_constraint(CONSTRAINT_NAME, type_="unique")

--- a/tests/test_unique_enrollment_constraint.py
+++ b/tests/test_unique_enrollment_constraint.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""One enrollment per (usuario, curso), enforced by the database.
+
+The enrollment paths upsert, so duplicates should never reach the table — this
+covers the case where something gets past them anyway.
+
+The migration's dedup path (collapsing duplicates that already exist, and
+repointing anything referencing a discarded row) is exercised against real
+PostgreSQL rather than here: SQLite is too permissive about constraints and
+foreign keys for that to prove anything. See the PR for that run.
+"""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from now_lms.auth import proteger_passwd
+from now_lms.db import Curso, EstudianteCurso, Usuario, database
+
+
+@pytest.fixture()
+def enrolled_student(app):
+    """A student with exactly one enrollment in a free course."""
+    with app.app_context():
+        s = database.session
+        s.add(
+            Curso(
+                nombre="Unique constraint course",
+                codigo="UQCHK",
+                descripcion="Unique-constraint test course.",
+                descripcion_corta="Unique check.",
+                estado="open",
+                publico=True,
+                pagado=False,
+                auditable=False,
+                certificado=False,
+                modalidad="self_paced",
+                creado_por="test",
+            )
+        )
+        s.add(
+            Usuario(
+                usuario="uq@example.test",
+                acceso=proteger_passwd("uq-test-pw-123"),
+                nombre="Unique",
+                apellido="Check",
+                correo_electronico="uq@example.test",
+                tipo="student",
+                activo=True,
+                correo_electronico_verificado=True,
+                creado_por="test",
+            )
+        )
+        s.flush()
+        s.add(EstudianteCurso(curso="UQCHK", usuario="uq@example.test", vigente=True, creado_por="test"))
+        s.commit()
+    return "uq@example.test", "UQCHK"
+
+
+def test_the_model_declares_the_constraint(app):
+    """The constraint has to be on the model, or a fresh install will not have it."""
+    names = {constraint.name for constraint in EstudianteCurso.__table__.constraints}
+    assert "uq_estudiante_curso_usuario_curso" in names
+
+
+def test_a_second_enrollment_row_is_rejected(app, enrolled_student):
+    """The point of the constraint: the same pair cannot be inserted twice."""
+    usuario, curso = enrolled_student
+    with app.app_context():
+        database.session.add(EstudianteCurso(curso=curso, usuario=usuario, vigente=True, creado_por="test"))
+        with pytest.raises(IntegrityError):
+            database.session.commit()
+        database.session.rollback()
+
+
+def test_the_same_student_can_still_join_another_course(app, enrolled_student):
+    """The constraint is on the pair, not on either column alone."""
+    usuario, _ = enrolled_student
+    with app.app_context():
+        s = database.session
+        s.add(
+            Curso(
+                nombre="Second course",
+                codigo="UQCHK2",
+                descripcion="Second course.",
+                descripcion_corta="Second.",
+                estado="open",
+                publico=True,
+                pagado=False,
+                auditable=False,
+                certificado=False,
+                modalidad="self_paced",
+                creado_por="test",
+            )
+        )
+        s.flush()
+        s.add(EstudianteCurso(curso="UQCHK2", usuario=usuario, vigente=True, creado_por="test"))
+        s.commit()
+
+        rows = s.execute(database.select(EstudianteCurso).filter_by(usuario=usuario)).scalars().all()
+        assert len(rows) == 2

--- a/tests/test_unique_enrollment_migration.py
+++ b/tests/test_unique_enrollment_migration.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 BMO Soluciones, S.A.
+
+"""The dedup half of the unique-enrollment migration.
+
+Existing installs are likely to hold duplicate (usuario, curso) rows already, so
+the migration collapses them before adding the constraint. These tests drive
+``upgrade()`` through a real Alembic operations context against a throwaway
+SQLite database, which covers the keeper-selection and child-repoint logic.
+
+Constraint *behaviour* — that the database then refuses a duplicate, that a
+re-run is a no-op, that downgrade drops it cleanly — is verified separately
+against real PostgreSQL, because SQLite is too permissive about constraints and
+foreign keys for a green run here to prove it. See PR #234 for that run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "now_lms"
+    / "migrations"
+    / "20260730_000000_unique_enrollment_per_student_and_course.py"
+)
+
+SCHEMA = [
+    """
+    CREATE TABLE estudiante_curso (
+        id VARCHAR(26) PRIMARY KEY,
+        curso VARCHAR(20) NOT NULL,
+        usuario VARCHAR(150) NOT NULL,
+        vigente BOOLEAN,
+        pago VARCHAR(26)
+    )
+    """,
+    """
+    CREATE TABLE remote_enrollment_requests (
+        id VARCHAR(26) PRIMARY KEY,
+        request_id VARCHAR(100) NOT NULL UNIQUE,
+        enrollment_id VARCHAR(26) REFERENCES estudiante_curso(id),
+        status VARCHAR(50) NOT NULL
+    )
+    """,
+]
+
+
+@pytest.fixture()
+def migration():
+    spec = importlib.util.spec_from_file_location("mig_unique_enrollment", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def engine(tmp_path):
+    eng = sa.create_engine(f"sqlite:///{tmp_path / 'dedup.db'}")
+    with eng.begin() as conn:
+        for statement in SCHEMA:
+            conn.execute(sa.text(statement))
+    yield eng
+    eng.dispose()
+
+
+def _enroll(conn, row_id, usuario, curso, vigente=True, pago=None):
+    conn.execute(
+        sa.text(
+            "INSERT INTO estudiante_curso (id, curso, usuario, vigente, pago) "
+            "VALUES (:id, :curso, :usuario, :vigente, :pago)"
+        ),
+        {"id": row_id, "curso": curso, "usuario": usuario, "vigente": vigente, "pago": pago},
+    )
+
+
+def _run_upgrade(engine, migration):
+    with engine.begin() as conn:
+        ctx = MigrationContext.configure(conn)
+        with Operations.context(ctx):
+            migration.upgrade()
+
+
+def _ids(engine, usuario="dup@example.test", curso="DUP"):
+    with engine.connect() as conn:
+        return [
+            r[0]
+            for r in conn.execute(
+                sa.text("SELECT id FROM estudiante_curso WHERE usuario = :u AND curso = :c"),
+                {"u": usuario, "c": curso},
+            )
+        ]
+
+
+def test_duplicates_collapse_to_one_row(engine, migration):
+    with engine.begin() as conn:
+        _enroll(conn, "A", "dup@example.test", "DUP")
+        _enroll(conn, "B", "dup@example.test", "DUP")
+        _enroll(conn, "C", "dup@example.test", "DUP")
+
+    _run_upgrade(engine, migration)
+
+    assert len(_ids(engine)) == 1
+
+
+def test_the_row_with_a_payment_is_kept(engine, migration):
+    """Keeper preference: a paid enrollment outranks an unpaid one."""
+    with engine.begin() as conn:
+        _enroll(conn, "AAA_unpaid", "dup@example.test", "DUP", pago=None)
+        _enroll(conn, "ZZZ_paid", "dup@example.test", "DUP", pago="P1")
+
+    _run_upgrade(engine, migration)
+
+    # ZZZ sorts last by id, so an id-only rule would have kept AAA.
+    assert _ids(engine) == ["ZZZ_paid"]
+
+
+def test_an_active_row_outranks_an_inactive_one(engine, migration):
+    """Second preference, when neither row carries a payment."""
+    with engine.begin() as conn:
+        _enroll(conn, "AAA_inactive", "dup@example.test", "DUP", vigente=False)
+        _enroll(conn, "ZZZ_active", "dup@example.test", "DUP", vigente=True)
+
+    _run_upgrade(engine, migration)
+
+    assert _ids(engine) == ["ZZZ_active"]
+
+
+def test_oldest_wins_when_nothing_else_separates_them(engine, migration):
+    """Last resort: lowest id, which is the oldest ULID."""
+    with engine.begin() as conn:
+        _enroll(conn, "AAA_older", "dup@example.test", "DUP")
+        _enroll(conn, "ZZZ_newer", "dup@example.test", "DUP")
+
+    _run_upgrade(engine, migration)
+
+    assert _ids(engine) == ["AAA_older"]
+
+
+def test_a_child_request_is_repointed_not_orphaned(engine, migration):
+    """A remote_enrollment_request pointing at a discarded row must follow the keeper."""
+    with engine.begin() as conn:
+        _enroll(conn, "KEEP", "dup@example.test", "DUP", pago="P1")
+        _enroll(conn, "DROP_ME", "dup@example.test", "DUP", pago=None)
+        conn.execute(
+            sa.text(
+                "INSERT INTO remote_enrollment_requests (id, request_id, enrollment_id, status) "
+                "VALUES ('R1', 'req-1', 'DROP_ME', 'processed')"
+            )
+        )
+
+    _run_upgrade(engine, migration)
+
+    with engine.connect() as conn:
+        pointed_at = conn.execute(
+            sa.text("SELECT enrollment_id FROM remote_enrollment_requests WHERE request_id = 'req-1'")
+        ).scalar()
+    assert pointed_at == "KEEP"
+
+
+def test_unrelated_enrollments_are_left_alone(engine, migration):
+    with engine.begin() as conn:
+        _enroll(conn, "A", "dup@example.test", "DUP")
+        _enroll(conn, "B", "dup@example.test", "DUP")
+        _enroll(conn, "OTHER_COURSE", "dup@example.test", "OTHER")
+        _enroll(conn, "OTHER_USER", "someone@example.test", "DUP")
+
+    _run_upgrade(engine, migration)
+
+    with engine.connect() as conn:
+        total = conn.execute(sa.text("SELECT count(*) FROM estudiante_curso")).scalar()
+    assert total == 3  # one survivor for the duplicated pair, plus the two untouched rows
+
+
+def test_upgrade_is_a_no_op_without_duplicates(engine, migration):
+    with engine.begin() as conn:
+        _enroll(conn, "ONLY", "dup@example.test", "DUP")
+
+    _run_upgrade(engine, migration)
+
+    assert _ids(engine) == ["ONLY"]
+
+
+def test_upgrade_survives_a_missing_child_table(tmp_path, migration):
+    """An install without remote_enrollment_requests must still migrate."""
+    eng = sa.create_engine(f"sqlite:///{tmp_path / 'nochild.db'}")
+    with eng.begin() as conn:
+        conn.execute(sa.text(SCHEMA[0]))
+        _enroll(conn, "A", "dup@example.test", "DUP")
+        _enroll(conn, "B", "dup@example.test", "DUP")
+
+    _run_upgrade(eng, migration)
+
+    with eng.connect() as conn:
+        remaining = conn.execute(sa.text("SELECT count(*) FROM estudiante_curso")).scalar()
+    eng.dispose()
+    assert remaining == 1


### PR DESCRIPTION
## What

Belt and braces for the upsert in #233: a `UniqueConstraint` on `estudiante_curso (usuario, curso)`, on the model plus a migration for existing installs.

A second enrollment row for the same student and course has never meant anything — it just inflates the counts everything else reads. #233 stops the enrollment paths from creating one; this stops a future bug or an impatient double-submit from getting past them.

**Depends on #233** in spirit rather than mechanically: merged alone, this constraint would turn today's duplicate-creating double-submit into an `IntegrityError` instead of silent bad data. Better than the status quo, but #233 is the one that makes it a non-event. Happy for you to take them in either order, or to rebase this on top of that branch if you prefer.

## The migration is the interesting part

It cannot just add the constraint. Any install that has been running a while very likely **already holds duplicates**, and the `ALTER` would simply fail. So it collapses them first:

- For each duplicated pair, keep one row — preferring a row that carries a payment, then an active one, then the oldest.
- **Repoint `remote_enrollment_requests.enrollment_id` at the keeper before deleting the others**, so a request that referenced a discarded enrollment is neither orphaned nor blocked by the foreign key.
- Then add the constraint, skipping it if it is somehow already there.

Keeper ordering happens in Python, not SQL, because boolean and `NULL` ordering differ between SQLite, PostgreSQL and MySQL and the rule shouldn't.

## Verified against real PostgreSQL, not SQLite

SQLite is far too permissive about constraints and foreign keys for a green run there to mean anything — so I drove the migration through a genuine Alembic operations context against PostgreSQL 16, on a database seeded with **three duplicate rows, one unrelated enrollment, and a `remote_enrollment_requests` row deliberately pointing at a row that had to lose**:

```
before: 4 enrollment rows (3 duplicates + 1 unrelated)

== upgrade ==
  PASS  one enrollment row survives for the duplicated pair: 1
  PASS  the row carrying a payment is the keeper: 'E_WITH_PAGO'
  PASS  the child request was repointed, not orphaned: 'E_WITH_PAGO'
  PASS  the unrelated enrollment was left alone: 1
  PASS  the unique constraint exists: 1

== postgres now rejects a duplicate ==
  PASS  a second row for the same (usuario, curso) is refused: True

== idempotency: upgrade twice must not explode ==
  PASS  re-running upgrade is a no-op: True

== downgrade ==
  PASS  the constraint is gone after downgrade: 0

RESULT: ALL CHECKS PASSED
```

## Committed tests

`tests/test_unique_enrollment_constraint.py` covers the model side — the constraint is declared (so a fresh `create_all()` install gets it), a duplicate insert raises `IntegrityError`, and the same student can still enroll in a *different* course (the constraint is on the pair, not either column). **Mutation-checked:** removing the model constraint fails 2 of the 3.

The migration's dedup path is deliberately not asserted in the SQLite suite, for the reason above; the docstring says so and points here.

`tests/test_coupons.py` and `tests/test_basicos.py` stay green. `ruff` + `flake8` clean; `pylint` **10.00/10** on the migration.

## Risk

The real one: **downgrade drops the constraint but does not resurrect the collapsed rows.** That is called out in the migration docstring, because it is not reversible and an operator should know before running it. Given duplicates were never meaningful, I judged collapsing them the right call rather than refusing to migrate — but if you would rather the migration *abort* on finding duplicates and make the operator clean up deliberately, that is a one-line change and I am happy to make it.

Branched from `main` at v2.0.1 (`6baac92`). Revision `20260730_000000`, revising `20260726_000000` (the current head).

- Jeremy Longshore
intentsolutions.io
